### PR TITLE
Update to verify the Rendezvous certificates

### DIFF
--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/SslContextFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/SslContextFactory.java
@@ -16,16 +16,10 @@
 
 package org.sdo.iotplatformsdk.common.protocol.config;
 
-import java.net.Socket;
-import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509ExtendedTrustManager;
 
 import org.slf4j.LoggerFactory;
 
@@ -45,42 +39,12 @@ public class SslContextFactory implements ObjectFactory<SSLContext> {
   public SSLContext getObject() {
     if (null == sslContext) {
       try {
-        initializeObject();
-      } catch (KeyManagementException | NoSuchAlgorithmException e) {
-        LoggerFactory.getLogger(getClass()).debug("Unable to create SSLContext.");
+        sslContext = SSLContext.getDefault();
+      } catch (NoSuchAlgorithmException e) {
+        LoggerFactory.getLogger(getClass()).debug("Unable to create default SSLContext.");
       }
     }
     return sslContext;
-  }
-
-  private void initializeObject() throws NoSuchAlgorithmException, KeyManagementException {
-    TrustManager[] trustManagers = new TrustManager[] {new X509ExtendedTrustManager() {
-      @Override
-      public void checkClientTrusted(X509Certificate[] chain, String authType, Socket s) {}
-
-      @Override
-      public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine e) {}
-
-      @Override
-      public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {}
-
-      @Override
-      public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {}
-
-      @Override
-      public void checkServerTrusted(X509Certificate[] chain, String authType, Socket s) {}
-
-      @Override
-      public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine e) {}
-
-      @Override
-      public X509Certificate[] getAcceptedIssuers() {
-        return new X509Certificate[0];
-      }
-    } };
-    sslContext = SSLContext.getInstance("TLS");
-    sslContext.init(null, trustManagers, getSecureRandom());
-    LoggerFactory.getLogger(getClass()).debug("UNSAFE: no-op TrustManager installed");
   }
 
   public SecureRandom getSecureRandom() {

--- a/demo/to0scheduler/config/application.properties
+++ b/demo/to0scheduler/config/application.properties
@@ -33,6 +33,12 @@ org.sdo.to0.ownersign.to0d.ws=PT1H
 # If no URI is specified, the default value of each individual property is used.
 org.sdo.to0.ownersign.to1d.bo=./redirect.properties
 
+# Boolean (Optional)
+# true: Certificate verification is disabled for the outgoing TLS connections to Rendezvous.
+# false: Certificate validation is done for the outgoing TLS connections to Rendezvous.
+# Default value: false
+# org.sdo.to0.tls.test-mode=false
+
 #########################################
 # To0Scheduler Communication Properties #
 #########################################

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/OpsCustomSslContextFactory.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/OpsCustomSslContextFactory.java
@@ -77,7 +77,7 @@ public class OpsCustomSslContextFactory extends SslContextFactory {
       final TrustManager[] tm = tmf.getTrustManagers();
 
       final SSLContext sslContext = SSLContext.getInstance("TLS");
-      sslContext.init(km, tm, new SecureRandom());
+      sslContext.init(km, tm, getSecureRandom());
       return sslContext;
     } catch (Exception e) {
       LOGGER.error("Error occurred while creating ssl context. ", e.getMessage());

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0CustomSslContextFactory.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0CustomSslContextFactory.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Creates and returns a custom {@link SSLContext} by loading a separate keystore and truststore.
+ * Used specifically for outgoing connections to Owner Companion Service.
  */
 public class To0CustomSslContextFactory extends SslContextFactory {
 
@@ -77,7 +78,7 @@ public class To0CustomSslContextFactory extends SslContextFactory {
       final TrustManager[] tm = tmf.getTrustManagers();
 
       final SSLContext sslContext = SSLContext.getInstance("TLS");
-      sslContext.init(km, tm, new SecureRandom());
+      sslContext.init(km, tm, getSecureRandom());
       return sslContext;
     } catch (Exception e) {
       LOGGER.error("Error occurred while creating ssl context. ", e.getMessage());

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0NoopSslContextFactory.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0NoopSslContextFactory.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.sdo.iotplatformsdk.to0scheduler.rest;
+
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+
+import org.sdo.iotplatformsdk.common.protocol.config.SslContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Create and return a custom {@link SSLContext} using a NO-OP {@link TrustManager}.
+ * Used specifically for outgoing connections to Rendezvous during TransferOwnership Protocol 0.
+ */
+public class To0NoopSslContextFactory extends SslContextFactory {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(To0NoopSslContextFactory.class);
+
+  public To0NoopSslContextFactory(SecureRandom secureRandom) {
+    super(secureRandom);
+  }
+
+  @Override
+  public SSLContext getObject() {
+    try {
+      final TrustManager[] trustManagers = new TrustManager[] {new X509ExtendedTrustManager() {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, Socket s) {}
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine e) {}
+
+        @Override
+        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {}
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {}
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, Socket s) {}
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine e) {}
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+          return new X509Certificate[0];
+        }
+      } };
+      final SSLContext sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(null, trustManagers, getSecureRandom());
+      LOGGER.debug("UNSAFE: no-op TrustManager installed for outgoing connections to Rendezvous.");
+      return sslContext;
+    } catch (NoSuchAlgorithmException | KeyManagementException e) {
+      LOGGER.error("Error occurred while creating custom ssl context for Rendezvous. ",
+          e.getMessage());
+      LOGGER.debug(e.getMessage(), e);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
1. Update to use the default SSLContext for outgoing Transfer Ownership
0 connections to Rendezvous, that enables the usual certificate
verification of the server during TLS handshake.
2. Added a 'test-mode' property for outgoing connections to
Rendezvous, which when enabled, ignores the server certificate
verification operation during TLS hadshake.
3. Update to use the instance variable secureRandom of the base
SSLContextFactory, in its children classes.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>