### PR TITLE
Adding Resale-support option for Owner

### DIFF
--- a/demo/ocs/config/application.properties
+++ b/demo/ocs/config/application.properties
@@ -50,6 +50,11 @@ to0.scheduler.interval=60
 # If false, OCS sends a new GUID and new/same Rendezvous information.
 to2.credential-reuse.enabled=false
 
+# The flag that determines whether the Resale protocol is supported by the Owner.
+# If true, resale protocol is supported as per the specification.
+# Default: true
+# to2.owner-resale.enabled=true
+
 ##########################
 # Mutual TLS Properties #
 ##########################

--- a/demo/ops/config/application.properties
+++ b/demo/ops/config/application.properties
@@ -69,6 +69,9 @@ rest.api.ciphers.path=v1/ciphers/{deviceId}
 # REST endpoint path at OCS for session info operations: URI
 rest.api.session.path=v1/devices/{deviceId}/sessioninfo
 
+# REST endpoint path at OCS to fetch owner resale support flag per device: URI
+rest.api.owner.resale.support.path=v1/devices/{deviceId}/resale
+
 # The keystore-type
 client.ssl.key-store-type=PKCS12
 

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsOcsContractImpl.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsOcsContractImpl.java
@@ -118,7 +118,11 @@ public class FsOcsContractImpl implements OcsRestContract {
   private final String valuesDir = FsPropertiesLoader.getProperty("fs.values.dir");
   private final boolean to2ReuseEnabled =
       FsPropertiesLoader.getProperty("to2.credential-reuse.enabled") != null
-          ? Boolean.getBoolean(FsPropertiesLoader.getProperty("to2.credential-reuse.enabled"))
+          ? Boolean.valueOf(FsPropertiesLoader.getProperty("to2.credential-reuse.enabled"))
+          : false;
+  private final boolean to2ResaleEnabled =
+      FsPropertiesLoader.getProperty("to2.owner-resale.enabled") != null
+          ? Boolean.valueOf(FsPropertiesLoader.getProperty("to2.owner-resale.enabled"))
           : true;
   // interval at which to0 scheduler will run repeatedly. Default: 60 seconds.
   private final int toSchedulerInterval =
@@ -956,5 +960,13 @@ public class FsOcsContractImpl implements OcsRestContract {
   @Override
   public void deleteDevice(String deviceId) throws Exception {
     getDataManager().removeObject(devicesDir + File.separator + deviceId);
+  }
+
+  /*
+   * Ignores device identifier, and returns the universal to2ResaleEnabled flag.
+   */
+  @Override
+  public boolean isOwnerResaleSupported(String deviceId) throws Exception {
+    return to2ResaleEnabled;
   }
 }

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/OcsRestController.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/OcsRestController.java
@@ -568,4 +568,26 @@ public final class OcsRestController {
       }
     });
   }
+
+  /**
+   * Returns the boolean value representing whether the Resale protocol is supported for the
+   * specified device.
+   *
+   * @param deviceId the device identifier.
+   * @return boolean value 'true' or 'false'
+   */
+  @GetMapping(path = "/devices/{deviceId}/resale", produces = MediaType.APPLICATION_JSON_VALUE)
+  public Mono<ResponseEntity<Boolean>>
+      getResaleFlag(@PathVariable(value = "deviceId", required = true) final String deviceId) {
+    return Mono.defer(() -> {
+      try {
+        final boolean response = ocsRestContractImpl.isOwnerResaleSupported(deviceId);
+        return Mono.just(new ResponseEntity<Boolean>(Boolean.valueOf(response), HttpStatus.OK));
+      } catch (Exception e) {
+        LOGGER.error(e.getMessage());
+        LOGGER.debug(e.getMessage(), e);
+        return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build());
+      }
+    });
+  }
 }

--- a/ocs/libocs/src/main/java/org/sdo/iotplatformsdk/ocs/services/OcsRestContract.java
+++ b/ocs/libocs/src/main/java/org/sdo/iotplatformsdk/ocs/services/OcsRestContract.java
@@ -227,4 +227,13 @@ public interface OcsRestContract {
    */
   public void deleteDevice(String deviceId) throws Exception;
 
+  /**
+   * Return boolean value representing whether the Owner supports the Resale
+   * protocol as per the specification, for the given device identifier.
+   *
+   * @param deviceId the device identifier.
+   * @return boolean value 'true' or 'false'
+   * @throws Exception Exception that is thrown in case of any operational error.
+   */
+  public boolean isOwnerResaleSupported(String deviceId) throws Exception;
 }

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/OwnerResaleSupport.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/OwnerResaleSupport.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.sdo.iotplatformsdk.ops.to2library;
+
+public interface OwnerResaleSupport {
+
+  /**
+   * Check if the 'Resale' protocol is supported by the Owner for the given device Identifier,
+   * as per the protocol specification.
+   *
+   * @param deviceId device identifier
+   * @return boolean value
+   */
+  public boolean ownerResaleSupported(String deviceId);
+}

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/config/OpsConfiguration.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/config/OpsConfiguration.java
@@ -31,6 +31,7 @@ import org.sdo.iotplatformsdk.ops.opsimpl.OpsAsymKexCodec;
 import org.sdo.iotplatformsdk.ops.opsimpl.OpsOwnerEventHandlerFactory;
 import org.sdo.iotplatformsdk.ops.opsimpl.OpsPropertiesLoader;
 import org.sdo.iotplatformsdk.ops.opsimpl.OpsProxyStorage;
+import org.sdo.iotplatformsdk.ops.opsimpl.OpsResaleSupport;
 import org.sdo.iotplatformsdk.ops.opsimpl.OpsServiceInfoModule;
 import org.sdo.iotplatformsdk.ops.opsimpl.OpsSessionStorageFactory;
 import org.sdo.iotplatformsdk.ops.opsimpl.OpsSetupDeviceServiceInfo;
@@ -50,6 +51,7 @@ import org.sdo.iotplatformsdk.ops.to2library.Message46Handler;
 import org.sdo.iotplatformsdk.ops.to2library.Message48Handler;
 import org.sdo.iotplatformsdk.ops.to2library.Message50Handler;
 import org.sdo.iotplatformsdk.ops.to2library.OwnerEventHandler;
+import org.sdo.iotplatformsdk.ops.to2library.OwnerResaleSupport;
 import org.sdo.iotplatformsdk.ops.to2library.SessionStorage;
 import org.sdo.iotplatformsdk.ops.to2library.SetupDeviceService;
 import org.slf4j.Logger;
@@ -254,6 +256,15 @@ public class OpsConfiguration implements WebMvcConfigurer {
   }
 
   /**
+   * Creates and returns a singleton instance of {@link OpsResaleSupport}.
+   * Calls to this method returns the same instance, always.
+   */
+  @Bean
+  protected OwnerResaleSupport ownerResaleSupport() {
+    return new OpsResaleSupport(restClient());
+  }
+
+  /**
    * Creates and returns a singleton instance of {@link Message40Handler}.
    * Calls to this method returns the same instance, always.
    */
@@ -318,7 +329,7 @@ public class OpsConfiguration implements WebMvcConfigurer {
   protected Message50Handler message50Handler() throws Exception {
     return new Message50Handler(ownerEventHandlerFactory().getObject(),
         sessionStorageFactory().getObject(), ownershipProxyStorage(),
-        secureRandomFactory().getObject(), keyExchangeDecoder());
+        secureRandomFactory().getObject(), keyExchangeDecoder(), ownerResaleSupport());
   }
 
   /**

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsResaleSupport.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsResaleSupport.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.sdo.iotplatformsdk.ops.opsimpl;
+
+import org.sdo.iotplatformsdk.ops.rest.RestClient;
+import org.sdo.iotplatformsdk.ops.to2library.OwnerResaleSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpsResaleSupport implements OwnerResaleSupport {
+
+  protected static final Logger LOGGER = LoggerFactory.getLogger(OpsResaleSupport.class);
+  private final RestClient restClient;
+
+  /**
+   * Constructor.
+   */
+  public OpsResaleSupport(RestClient restClient) {
+    this.restClient = restClient;
+  }
+
+  @Override
+  public boolean ownerResaleSupported(String deviceId) {
+    try {
+      return restClient.getOwnerResaleFlag(deviceId);
+    } catch (Exception e) {
+      LOGGER.debug("Error while fetching resale support flag. Defaulting to return true.");
+      return true;
+    }
+  }
+}

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/RestClient.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/RestClient.java
@@ -504,4 +504,33 @@ public class RestClient {
       logger.debug(e.getMessage(), e);
     }
   }
+
+  /**
+   * Send a GET request to check whether the 'Resale' protocol for the specified device identifier,
+   * is supported or not. If an exception occurs, this method returns true.
+   *
+   * @param deviceId the device identifier.
+   * @return boolean value.
+   */
+  public boolean getOwnerResaleFlag(final String deviceId) {
+    try {
+      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      interceptors.add(
+          new RestHeaderRequestInterceptor(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE));
+
+      final String apiServer = OpsPropertiesLoader.getProperty("rest.api.server");
+      final String path = OpsPropertiesLoader.getProperty("rest.api.owner.resale.support.path");
+      final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
+
+      final RestTemplate restTemplate = getRestTemplate();
+      restTemplate.setInterceptors(interceptors);
+      final String url = builder.buildAndExpand(deviceId.toString()).toString();
+      return restTemplate.getForObject(url, Boolean.class);
+    } catch (Exception e) {
+      logger.error(
+          "Error occurred while fetching resale flag for " + deviceId + ". " + e.getMessage());
+      logger.debug(e.getMessage(), e);
+      return true;
+    }
+  }
 }

--- a/ops/restimpl/src/test/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsResaleSupportTest.java
+++ b/ops/restimpl/src/test/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsResaleSupportTest.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright 2020 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.sdo.iotplatformsdk.ops.opsimpl;
+
+import junit.framework.TestCase;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.sdo.iotplatformsdk.ops.rest.RestClient;
+
+@RunWith(JUnit4.class)
+public class OpsResaleSupportTest extends TestCase {
+
+  @Mock
+  RestClient restClient;
+  OpsResaleSupport opsResaleSupport;
+
+  @Override
+  @Before
+  public void setUp() {
+    restClient = Mockito.mock(RestClient.class);
+    opsResaleSupport = new OpsResaleSupport(restClient);
+  }
+
+  @Test()
+  public void testOwnerResaleSupported() {
+    Mockito.when(restClient.getOwnerResaleFlag(Mockito.anyString())).thenReturn(false);
+    Assert.assertFalse(opsResaleSupport.ownerResaleSupported(Mockito.anyString()));
+    Mockito.when(restClient.getOwnerResaleFlag(Mockito.anyString())).thenReturn(true);
+    Assert.assertTrue(opsResaleSupport.ownerResaleSupported(Mockito.anyString()));
+    Mockito.when(restClient.getOwnerResaleFlag(Mockito.anyString()))
+        .thenThrow(new RuntimeException());
+    Assert.assertTrue(opsResaleSupport.ownerResaleSupported(Mockito.anyString()));
+  }
+}


### PR DESCRIPTION
1. Added REST API at OCS, which is called upon by OPS during Transfer
Ownership 2, Type 50, to know whether the RESALE protocol should be
supported for a particular device. By default, RESALE is supported.
2. To facilitate the above, adding a sample RESALE flag at OCS, which when
set to true, indicates that the Owner supports resale protocol for all
the devices. By default, RESALE is flag is set to true.
3. Fixing an issue where the credential-reuse flag was being processed
incorrectly, and setting the default value to false.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>