### PR TITLE
Updating OPS RestClient and swagger.yml

### DIFF
--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/OcsRestController.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/OcsRestController.java
@@ -66,8 +66,7 @@ public final class OcsRestController {
    * @param deviceId the device identifier.
    * @return owner voucher of the device.
    */
-  @GetMapping(path = "/devices/{deviceId}/voucher",
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @GetMapping(path = "/devices/{deviceId}/voucher", produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity<String>>
       getDeviceVoucher(@PathVariable(value = "deviceId", required = true) final String deviceId) {
 
@@ -92,7 +91,7 @@ public final class OcsRestController {
    * @param voucher  owner voucher json contents.
    * @return
    */
-  @PostMapping(path = "/devices/voucher", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @PostMapping(path = "/devices/voucher", consumes = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity> putDeviceVoucher(@RequestBody(required = true) final String voucher) {
 
     return Mono.defer(() -> {
@@ -115,7 +114,7 @@ public final class OcsRestController {
    * @param deviceId the device identifier.
    * @return the state information of the device.
    */
-  @GetMapping(path = "/devices/{deviceId}/state", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @GetMapping(path = "/devices/{deviceId}/state", produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity<DeviceState>>
       getDeviceState(@PathVariable(value = "deviceId", required = true) final String deviceId) {
 
@@ -140,7 +139,7 @@ public final class OcsRestController {
    * @param stateInfo the state information of the device.
    * @return
    */
-  @PostMapping(path = "/devices/{deviceId}/state", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @PostMapping(path = "/devices/{deviceId}/state", consumes = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity> postState(
       @PathVariable(value = "deviceId", required = true) final String deviceId,
       @RequestBody(required = true) final DeviceState stateInfo) {
@@ -167,7 +166,7 @@ public final class OcsRestController {
    * @param deviceId the device identifier
    * @return an array of serviceinfo messages.
    */
-  @GetMapping(path = "/devices/{deviceId}/msgs", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @GetMapping(path = "/devices/{deviceId}/msgs", produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity<SviMessage[]>>
       getServiceInfo(@PathVariable(value = "deviceId", required = true) final String deviceId) {
 
@@ -192,7 +191,7 @@ public final class OcsRestController {
    * @param sviMessages an array of serviceinfo messages.
    * @return
    */
-  @PutMapping(path = "/devices/{deviceId}/msgs", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @PutMapping(path = "/devices/{deviceId}/msgs", produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity> putSvi(
       @PathVariable(value = "deviceId", required = true) final String deviceId,
       @RequestBody(required = true) final SviMessage[] sviMessages) {
@@ -217,8 +216,7 @@ public final class OcsRestController {
    * @param deviceId the device identifier.
    * @return
    */
-  @DeleteMapping(path = "/devices/{deviceId}/msgs",
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @DeleteMapping(path = "/devices/{deviceId}/msgs", produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity>
       deleteSvi(@PathVariable(value = "deviceId", required = true) final String deviceId) {
 
@@ -244,7 +242,7 @@ public final class OcsRestController {
    * @param message  device serviceinfo message.
    * @return
    */
-  @PostMapping(path = "/devices/{deviceId}/msgs", consumes = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @PostMapping(path = "/devices/{deviceId}/msgs", consumes = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity> postMessage(
       @PathVariable(value = "deviceId", required = true) final String deviceId,
       @RequestBody(required = true) final ModuleMessage[] message) {
@@ -304,7 +302,7 @@ public final class OcsRestController {
    * @return
    */
   @PutMapping(path = "/devices/{deviceId}/values/{valueId}",
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+      consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
   public Mono<ResponseEntity> putValue(
       @PathVariable(value = "deviceId", required = true) String deviceId,
       @PathVariable(value = "valueId", required = true) String valueId,
@@ -332,7 +330,7 @@ public final class OcsRestController {
    * @return
    */
   @DeleteMapping(path = "/devices/{deviceId}/values/{valueId}",
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+      produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity> deleteValue(
       @PathVariable(value = "deviceId", required = true) String deviceId,
       @PathVariable(value = "valueId", required = true) String valueId) {
@@ -358,7 +356,7 @@ public final class OcsRestController {
    * @param deviceId the device identifier.
    * @return pre-serviceinfo for the device.
    */
-  @GetMapping(path = "/devices/{deviceId}/psi", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @GetMapping(path = "/devices/{deviceId}/psi", produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity<ModuleMessage[]>>
       getPsi(@PathVariable(value = "deviceId", required = true) final String deviceId) {
 
@@ -383,8 +381,7 @@ public final class OcsRestController {
    * @param deviceId the device identifier.
    * @return an object containing the rendezvous information and guid.
    */
-  @GetMapping(path = "/devices/{deviceId}/setupinfo",
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @GetMapping(path = "/devices/{deviceId}/setupinfo", produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity<SetupInfoResponse>>
       getSetupInfo(@PathVariable(value = "deviceId", required = true) final String deviceId) {
     return Mono.defer(() -> {
@@ -407,8 +404,7 @@ public final class OcsRestController {
    * @param errorState the error information.
    * @return
    */
-  @PostMapping(path = "/devices/{deviceId}/errors",
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @PostMapping(path = "/devices/{deviceId}/errors", produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity> postErrors(
       @PathVariable(value = "deviceId", required = true) final String deviceId,
       @RequestBody(required = false) final DeviceState errorState) {
@@ -432,7 +428,7 @@ public final class OcsRestController {
    * @param input    the data to be signed.
    * @return the signature, public key and its algorithm.
    */
-  @PostMapping(path = "/signatures/{deviceId}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @PostMapping(path = "/signatures/{deviceId}", produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity<SignatureResponse>> postSignature(
       @PathVariable(value = "deviceId", required = true) final String deviceId,
       @RequestBody(required = false) final String input) {
@@ -456,7 +452,8 @@ public final class OcsRestController {
    * @param input the data to be deciphered.
    * @return byte array.
    */
-  @PostMapping(path = "/ciphers/{deviceId}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @PostMapping(path = "/ciphers/{deviceId}", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE,
+      consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
   public Mono<ResponseEntity<byte[]>> asymCipherOperations(
       @PathVariable(value = "deviceId", required = true) final String deviceId,
       @RequestParam(value = "operation", required = true) String operation,
@@ -479,8 +476,7 @@ public final class OcsRestController {
    * @param deviceId the device identifier.
    * @return the session information.
    */
-  @GetMapping(path = "/devices/{deviceId}/sessioninfo",
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @GetMapping(path = "/devices/{deviceId}/sessioninfo", produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity<To2DeviceSessionInfo>> getDeviceSessionInfo(
       @PathVariable(value = "deviceId", required = true) final String deviceId) {
 
@@ -507,7 +503,7 @@ public final class OcsRestController {
    * @return
    */
   @PostMapping(path = "/devices/{deviceId}/sessioninfo",
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+      consumes = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity> postDeviceSessionInfo(
       @PathVariable(value = "deviceId", required = true) final String deviceId,
       @RequestBody(required = false) final To2DeviceSessionInfo to2DeviceSessionInfo) {
@@ -530,7 +526,7 @@ public final class OcsRestController {
    * @return
    */
   @DeleteMapping(path = "/devices/{deviceId}/sessioninfo",
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+      produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity> postDeviceSessionInfo(
       @PathVariable(value = "deviceId", required = true) final String deviceId) {
     return Mono.defer(() -> {
@@ -551,8 +547,7 @@ public final class OcsRestController {
    * @param deviceId the device identifier.
    * @return
    */
-  @DeleteMapping(path = "/devices/{deviceId}/blob",
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @DeleteMapping(path = "/devices/{deviceId}/blob", produces = MediaType.APPLICATION_JSON_VALUE)
   public Mono<ResponseEntity>
       deleteDevice(@PathVariable(value = "deviceId", required = true) final String deviceId) {
     return Mono.defer(() -> {

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/RestClient.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/RestClient.java
@@ -19,9 +19,7 @@ package org.sdo.iotplatformsdk.ops.rest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
 import javax.net.ssl.SSLContext;
-
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -50,7 +48,6 @@ public class RestClient {
 
   private final Logger logger = LoggerFactory.getLogger(RestClient.class);
   private final SSLContext sslContext;
-  private final RestTemplate restTemplate;
   private HttpComponentsClientHttpRequestFactory requestFactory;
 
   /**
@@ -58,11 +55,6 @@ public class RestClient {
    */
   public RestClient(SSLContext sslContext) {
     this.sslContext = sslContext;
-    this.restTemplate = new RestTemplate(sslContext());
-  }
-
-  private RestTemplate getRestTemplate() {
-    return restTemplate;
   }
 
   /**
@@ -86,11 +78,6 @@ public class RestClient {
     return requestFactory;
   }
 
-  protected List<ClientHttpRequestInterceptor> getInspectors() {
-    List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
-    return interceptors;
-  }
-
   /**
    * Send a GET request to retrieve the owner voucher for the specified device identifier.
    *
@@ -99,7 +86,7 @@ public class RestClient {
    */
   public String getDeviceVoucher(final UUID deviceId) {
     try {
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(
           new RestHeaderRequestInterceptor(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE));
 
@@ -107,7 +94,7 @@ public class RestClient {
       final String path = OpsPropertiesLoader.getProperty("rest.api.voucher.path");
       final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
       final String url = builder.buildAndExpand(deviceId.toString()).toString();
       return restTemplate.getForObject(url, String.class);
@@ -124,7 +111,7 @@ public class RestClient {
    */
   public void putDeviceVoucher(final String ownerVoucher) {
     try {
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(new RestHeaderRequestInterceptor(HttpHeaders.CONTENT_TYPE,
           MediaType.APPLICATION_JSON_VALUE));
 
@@ -132,7 +119,7 @@ public class RestClient {
       final String path = OpsPropertiesLoader.getProperty("rest.api.voucher.path");
       final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
       final String url = builder.buildAndExpand("").toString();
       restTemplate.postForObject(url, ownerVoucher, String.class);
@@ -151,7 +138,7 @@ public class RestClient {
    */
   public void postDeviceState(final String deviceId, final DeviceState state) {
     try {
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(new RestHeaderRequestInterceptor(HttpHeaders.CONTENT_TYPE,
           MediaType.APPLICATION_JSON_VALUE));
 
@@ -159,7 +146,7 @@ public class RestClient {
       final String path = OpsPropertiesLoader.getProperty("rest.api.device.state.path");
       final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
 
       restTemplate.postForObject(builder.buildAndExpand(deviceId).toString(), state,
@@ -180,7 +167,7 @@ public class RestClient {
    */
   public SviMessage[] getMessage(final String deviceId) {
     try {
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(
           new RestHeaderRequestInterceptor(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE));
 
@@ -188,7 +175,7 @@ public class RestClient {
       final String path = OpsPropertiesLoader.getProperty("rest.api.serviceinfo.path");
       final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
 
       final SviMessage[] response = restTemplate
@@ -211,7 +198,7 @@ public class RestClient {
    */
   public void postMessage(final String deviceId, final List<ModuleMessage> messages) {
     try {
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(new RestHeaderRequestInterceptor(HttpHeaders.CONTENT_TYPE,
           MediaType.APPLICATION_JSON_VALUE));
 
@@ -219,7 +206,7 @@ public class RestClient {
       final String path = OpsPropertiesLoader.getProperty("rest.api.serviceinfo.path");
       final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
 
       restTemplate.postForObject(builder.buildAndExpand(deviceId).toString(), messages,
@@ -240,15 +227,15 @@ public class RestClient {
    */
   public ModuleMessage[] getPsi(final String deviceId) {
     try {
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
-      interceptors.add(new RestHeaderRequestInterceptor(HttpHeaders.CONTENT_TYPE,
-          MediaType.APPLICATION_JSON_VALUE));
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
+      interceptors.add(
+          new RestHeaderRequestInterceptor(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE));
 
       final String apiServer = OpsPropertiesLoader.getProperty("rest.api.server");
       final String path = OpsPropertiesLoader.getProperty("rest.api.psi.path");
       final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
 
       final ModuleMessage[] response = restTemplate
@@ -279,10 +266,10 @@ public class RestClient {
       final String path = OpsPropertiesLoader.getProperty("rest.api.serviceinfo.value.path");
       final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path)
           .queryParam("start", Integer.toString(start)).queryParam("end", Integer.toString(end));
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(new RestHeaderRequestInterceptor(HttpHeaders.ACCEPT,
           MediaType.APPLICATION_OCTET_STREAM_VALUE));
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
       final String[] pathParameters = {deviceId.toString(), valueId};
       final String restUrl = builder.buildAndExpand((Object[]) pathParameters).toString();
@@ -307,17 +294,17 @@ public class RestClient {
   public SignatureResponse signatureOperation(final UUID uuid, final String bo) {
     try {
 
-      List<ClientHttpRequestInterceptor> interceptors = getInspectors();
-      interceptors.add(new RestHeaderRequestInterceptor(HttpHeaders.CONTENT_TYPE,
-          MediaType.APPLICATION_JSON_VALUE));
-      RestTemplate restTemplate = getRestTemplate();
+      List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
+      interceptors.add(
+          new RestHeaderRequestInterceptor(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE));
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
 
       final String apiServer = OpsPropertiesLoader.getProperty("rest.api.server");
-      String path = OpsPropertiesLoader.getProperty("rest.api.signature.path");
-      UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
+      final String path = OpsPropertiesLoader.getProperty("rest.api.signature.path");
+      final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      SignatureResponse response = restTemplate
+      final SignatureResponse response = restTemplate
           .postForObject(builder.buildAndExpand(uuid).toString(), bo, SignatureResponse.class);
       return response;
 
@@ -340,15 +327,17 @@ public class RestClient {
   public byte[] cipherOperations(final byte[] xb, final String cipherOp, final UUID uuid) {
     try {
 
-      List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(new RestHeaderRequestInterceptor(HttpHeaders.CONTENT_TYPE,
-          MediaType.APPLICATION_JSON_VALUE));
-      RestTemplate restTemplate = getRestTemplate();
+          MediaType.APPLICATION_OCTET_STREAM_VALUE));
+      interceptors.add(new RestHeaderRequestInterceptor(HttpHeaders.ACCEPT,
+          MediaType.APPLICATION_OCTET_STREAM_VALUE));
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
 
       final String apiServer = OpsPropertiesLoader.getProperty("rest.api.server");
-      String path = OpsPropertiesLoader.getProperty("rest.api.ciphers.path");
-      UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path)
+      final String path = OpsPropertiesLoader.getProperty("rest.api.ciphers.path");
+      final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path)
           .queryParam("operation", cipherOp);
       final String restUrl = builder.buildAndExpand(uuid.toString()).toString();
       byte[] response = restTemplate.postForObject(restUrl, xb, byte[].class);
@@ -371,7 +360,7 @@ public class RestClient {
    */
   public SetupInfoResponse getSetupInfo(final String deviceId) {
     try {
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(
           new RestHeaderRequestInterceptor(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE));
 
@@ -379,7 +368,7 @@ public class RestClient {
       final String path = OpsPropertiesLoader.getProperty("rest.api.setupinfo.path");
       final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
 
       final SetupInfoResponse response = restTemplate
@@ -403,15 +392,15 @@ public class RestClient {
    */
   public void postError(final String deviceId, final DeviceState state) {
     try {
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(new RestHeaderRequestInterceptor(HttpHeaders.CONTENT_TYPE,
           MediaType.APPLICATION_JSON_VALUE));
 
       final String apiServer = OpsPropertiesLoader.getProperty("rest.api.server");
       final String path = OpsPropertiesLoader.getProperty("rest.api.error.path");
-      UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
+      final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
 
       restTemplate.postForObject(builder.buildAndExpand(deviceId).toString(), state,
@@ -432,15 +421,15 @@ public class RestClient {
    */
   public void postSessionState(final String deviceId, final To2DeviceSessionInfo session) {
     try {
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(new RestHeaderRequestInterceptor(HttpHeaders.CONTENT_TYPE,
           MediaType.APPLICATION_JSON_VALUE));
 
       final String apiServer = OpsPropertiesLoader.getProperty("rest.api.server");
       final String path = OpsPropertiesLoader.getProperty("rest.api.session.path");
-      UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
+      final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
 
       restTemplate.postForObject(builder.buildAndExpand(deviceId).toString(), session,
@@ -459,7 +448,7 @@ public class RestClient {
    */
   public To2DeviceSessionInfo getSessionState(final String deviceId) {
     try {
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(
           new RestHeaderRequestInterceptor(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE));
 
@@ -467,7 +456,7 @@ public class RestClient {
       final String path = OpsPropertiesLoader.getProperty("rest.api.session.path");
       final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
       final String url = builder.buildAndExpand(deviceId.toString()).toString();
       return restTemplate.getForObject(url, To2DeviceSessionInfo.class);
@@ -486,7 +475,7 @@ public class RestClient {
    */
   public void deleteSessionState(final String deviceId) {
     try {
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(
           new RestHeaderRequestInterceptor(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE));
 
@@ -494,7 +483,7 @@ public class RestClient {
       final String path = OpsPropertiesLoader.getProperty("rest.api.session.path");
       final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
       final String url = builder.buildAndExpand(deviceId.toString()).toString();
       restTemplate.delete(url);
@@ -514,7 +503,7 @@ public class RestClient {
    */
   public boolean getOwnerResaleFlag(final String deviceId) {
     try {
-      final List<ClientHttpRequestInterceptor> interceptors = getInspectors();
+      final List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
       interceptors.add(
           new RestHeaderRequestInterceptor(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE));
 
@@ -522,7 +511,7 @@ public class RestClient {
       final String path = OpsPropertiesLoader.getProperty("rest.api.owner.resale.support.path");
       final UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(apiServer).path(path);
 
-      final RestTemplate restTemplate = getRestTemplate();
+      final RestTemplate restTemplate = new RestTemplate(sslContext());
       restTemplate.setInterceptors(interceptors);
       final String url = builder.buildAndExpand(deviceId.toString()).toString();
       return restTemplate.getForObject(url, Boolean.class);

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -189,7 +189,7 @@ paths:
       summary: Updates a service info value for a device
       operationId: putSviValue
       consumes:
-      - application/json
+      - application/octet-stream
       produces:
       - application/json
       parameters:
@@ -395,7 +395,7 @@ paths:
       summary: Perform the cipher operation on input array of bytes and return the resulting array of bytes
       operationId: postCiphers
       consumes:
-      - application/json
+      - application/octet-stream
       produces:
       - application/octet-stream
       parameters:


### PR DESCRIPTION
Following updates have been made to resolve an issue where HTTP 406
error was encountered during service info transfer:
- RestClient at OPS uses a new instance of RestTemplate and interceptor
for each request.
- Updating the content-type of a couple of APIs to reflect the expected
behavior.
Additionally,
- Replacing the deprecated MediaType.APPLICATION_JSON_UTF8_VALUE with
MediaType.APPLICATION_JSON_VALUE at OcsRestController.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>