### PR TITLE
Fix: Update checkstyle version to 8.33

### DIFF
--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/AppIdCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/AppIdCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/ByteArrayCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/ByteArrayCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/CertPathCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/CertPathCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/CertificateCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/CertificateCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -30,7 +17,6 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
-
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/CipherTextCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/CipherTextCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -25,7 +12,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.CipherText;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/CipherTypeCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/CipherTypeCodec.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.CipherAlgorithm;
 import org.sdo.iotplatformsdk.common.protocol.types.CipherBlockMode;
 import org.sdo.iotplatformsdk.common.protocol.types.CipherType;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/Codec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/Codec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/DeviceStateCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/DeviceStateCodec.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.DeviceState;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/EncryptedMessageCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/EncryptedMessageCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.CipherText;
 import org.sdo.iotplatformsdk.common.protocol.types.EncryptedMessage;
 import org.sdo.iotplatformsdk.common.protocol.types.To2CipherHashMac;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/HashDigestCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/HashDigestCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -25,7 +12,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.DigestType;
 import org.sdo.iotplatformsdk.common.protocol.types.HashDigest;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/HashMacCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/HashMacCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -25,7 +12,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.HashMac;
 import org.sdo.iotplatformsdk.common.protocol.types.MacType;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/InetAddressCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/InetAddressCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -26,7 +13,6 @@ import java.io.Writer;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/IvDataCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/IvDataCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/Json.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/Json.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/KexParamCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/KexParamCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/KeyEncodingCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/KeyEncodingCodec.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.KeyEncoding;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/KeyExchangeTypeCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/KeyExchangeTypeCodec.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.KeyExchangeType;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/KeyTypeCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/KeyTypeCodec.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.KeyType;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/Matchers.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/Matchers.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/OwnershipProxyCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/OwnershipProxyCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -30,7 +17,6 @@ import java.nio.CharBuffer;
 import java.security.cert.CertPath;
 import java.util.LinkedList;
 import java.util.List;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.OwnershipProxyHeaderCodec.OwnershipProxyHeaderDecoder;
 import org.sdo.iotplatformsdk.common.protocol.codecs.OwnershipProxyHeaderCodec.OwnershipProxyHeaderEncoder;
 import org.sdo.iotplatformsdk.common.protocol.types.HashMac;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/OwnershipProxyEntryCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/OwnershipProxyEntryCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -25,7 +12,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
 import java.security.PublicKey;
-
 import org.sdo.iotplatformsdk.common.protocol.types.HashDigest;
 import org.sdo.iotplatformsdk.common.protocol.types.OwnershipProxyEntry;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/OwnershipProxyHeaderCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/OwnershipProxyHeaderCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -27,7 +14,6 @@ import java.nio.BufferUnderflowException;
 import java.nio.CharBuffer;
 import java.security.PublicKey;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.HashDigest;
 import org.sdo.iotplatformsdk.common.protocol.types.KeyEncoding;
 import org.sdo.iotplatformsdk.common.protocol.types.OwnershipProxyHeader;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkEpidCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkEpidCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -27,7 +14,6 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.PublicKey;
 import java.security.spec.EncodedKeySpec;
-
 import org.sdo.iotplatformsdk.common.protocol.types.EpidKey;
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkNullCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkNullCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkRmeCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkRmeCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -30,7 +17,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.RSAPublicKeySpec;
-
 import org.sdo.iotplatformsdk.common.protocol.types.Keys;
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkX509Codec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkX509Codec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -28,7 +15,6 @@ import java.nio.CharBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
-
 import org.sdo.iotplatformsdk.common.protocol.types.Keys;
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/PreServiceInfoCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/PreServiceInfoCodec.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.PreServiceInfo;
 import org.sdo.iotplatformsdk.common.protocol.types.PreServiceInfoEntry;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/PublicKeyCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/PublicKeyCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -25,7 +12,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
 import java.security.PublicKey;
-
 import org.sdo.iotplatformsdk.common.protocol.types.EpidKey10;
 import org.sdo.iotplatformsdk.common.protocol.types.EpidKey11;
 import org.sdo.iotplatformsdk.common.protocol.types.EpidKey20;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/RendezvousInfoCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/RendezvousInfoCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.RendezvousInfo;
 import org.sdo.iotplatformsdk.common.protocol.types.RendezvousInstr;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SdoDecoder.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SdoDecoder.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SdoEncoder.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SdoEncoder.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SdoErrorCodeCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SdoErrorCodeCodec.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.SdoErrorCode;
 
 public class SdoErrorCodeCodec extends Codec<SdoErrorCode> {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SdoErrorCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SdoErrorCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.SdoError;
 import org.sdo.iotplatformsdk.common.protocol.types.SdoErrorCode;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/ServiceInfoCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/ServiceInfoCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -26,7 +13,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfo;
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfoEntry;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SigInfoCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SigInfoCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -25,7 +12,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.SigInfo;
 import org.sdo.iotplatformsdk.common.protocol.types.SignatureType;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SignatureBlockCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SignatureBlockCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -29,7 +16,6 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.PublicKey;
 import java.util.function.Consumer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.SignatureBlock;
 
 public class SignatureBlockCodec {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SignatureTypeCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/SignatureTypeCodec.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.SignatureType;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/StringCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/StringCodec.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.Strings;
 
 public class StringCodec extends Codec<String> {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0AcceptOwnerCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0AcceptOwnerCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
 import java.time.Duration;
-
 import org.sdo.iotplatformsdk.common.protocol.types.To0AcceptOwner;
 
 public class To0AcceptOwnerCodec extends Codec<To0AcceptOwner> {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0HelloAckCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0HelloAckCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -23,7 +10,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.Nonce;
 import org.sdo.iotplatformsdk.common.protocol.types.To0HelloAck;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0HelloCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0HelloCodec.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.To0Hello;
 
 public class To0HelloCodec extends Codec<To0Hello> {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0OwnerSignCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0OwnerSignCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.To0OwnerSignTo0dCodec.To0dDecoder;
 import org.sdo.iotplatformsdk.common.protocol.codecs.To0OwnerSignTo0dCodec.To0dEncoder;
 import org.sdo.iotplatformsdk.common.protocol.types.SignatureBlock;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0OwnerSignTo0dCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0OwnerSignTo0dCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -25,7 +12,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
 import java.time.Duration;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.OwnershipProxyCodec.OwnershipProxyDecoder;
 import org.sdo.iotplatformsdk.common.protocol.codecs.OwnershipProxyCodec.OwnershipProxyEncoder;
 import org.sdo.iotplatformsdk.common.protocol.types.Nonce;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To1SdoRedirectCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To1SdoRedirectCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -26,7 +13,6 @@ import java.io.Writer;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.HashDigest;
 import org.sdo.iotplatformsdk.common.protocol.types.To1SdoRedirect;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2CipherHashMacCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2CipherHashMacCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -25,7 +12,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.HashMac;
 import org.sdo.iotplatformsdk.common.protocol.types.To2CipherHashMac;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2Done2Codec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2Done2Codec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -23,7 +10,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.Nonce;
 import org.sdo.iotplatformsdk.common.protocol.types.To2Done2;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2DoneCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2DoneCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.HashMac;
 import org.sdo.iotplatformsdk.common.protocol.types.Nonce;
 import org.sdo.iotplatformsdk.common.protocol.types.To2Done;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2GetNextDeviceServiceInfoCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2GetNextDeviceServiceInfoCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.PreServiceInfo;
 import org.sdo.iotplatformsdk.common.protocol.types.To2GetNextDeviceServiceInfo;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2GetNextOwnerServiceInfoCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2GetNextOwnerServiceInfoCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -23,7 +10,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.To2GetNextOwnerServiceInfo;
 
 public class To2GetNextOwnerServiceInfoCodec extends Codec<To2GetNextOwnerServiceInfo> {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2GetOpNextEntryCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2GetOpNextEntryCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -23,7 +10,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.To2GetOpNextEntry;
 
 public class To2GetOpNextEntryCodec extends Codec<To2GetOpNextEntry> {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2HelloDeviceCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2HelloDeviceCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -25,7 +12,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.CipherType;
 import org.sdo.iotplatformsdk.common.protocol.types.KeyEncoding;
 import org.sdo.iotplatformsdk.common.protocol.types.KeyExchangeType;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2NextDeviceServiceInfoCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2NextDeviceServiceInfoCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfo;
 import org.sdo.iotplatformsdk.common.protocol.types.To2NextDeviceServiceInfo;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2OpNextEntryCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2OpNextEntryCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.SignatureBlock;
 import org.sdo.iotplatformsdk.common.protocol.types.To2OpNextEntry;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2OwnerServiceInfoCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2OwnerServiceInfoCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -25,7 +12,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfo;
 import org.sdo.iotplatformsdk.common.protocol.types.To2OwnerServiceInfo;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2ProveDeviceCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2ProveDeviceCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -26,7 +13,6 @@ import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.Nonce;
 import org.sdo.iotplatformsdk.common.protocol.types.To2ProveDevice;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2ProveOpHdrCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2ProveOpHdrCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -25,7 +12,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.OwnershipProxyHeaderCodec.OwnershipProxyHeaderDecoder;
 import org.sdo.iotplatformsdk.common.protocol.codecs.OwnershipProxyHeaderCodec.OwnershipProxyHeaderEncoder;
 import org.sdo.iotplatformsdk.common.protocol.types.HashMac;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2SetupDeviceCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2SetupDeviceCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import static org.sdo.iotplatformsdk.common.protocol.codecs.Matchers.expect;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.types.SignatureBlock;
 import org.sdo.iotplatformsdk.common.protocol.types.To2SetupDevice;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2SetupDeviceNohCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2SetupDeviceNohCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -25,7 +12,6 @@ import java.io.IOException;
 import java.io.Writer;
 import java.nio.CharBuffer;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.Nonce;
 import org.sdo.iotplatformsdk.common.protocol.types.RendezvousInfo;
 import org.sdo.iotplatformsdk.common.protocol.types.To2SetupDeviceNoh;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/Uint16Codec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/Uint16Codec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/Uint32Codec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/Uint32Codec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/Uint8Codec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/Uint8Codec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/UintCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/UintCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/UriCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/UriCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/UuidCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/codecs/UuidCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/EpidOptionBean.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/EpidOptionBean.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.config;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/ObjectFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/ObjectFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.config;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/OwnershipProxyStorage.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/OwnershipProxyStorage.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.config;
 
 import java.io.IOException;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.OwnershipProxy;
 
 public interface OwnershipProxyStorage {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/SecureRandomFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/SecureRandomFactory.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.config;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/SslContextFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/SslContextFactory.java
@@ -1,26 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.config;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-
 import javax.net.ssl.SSLContext;
-
 import org.slf4j.LoggerFactory;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/TrustAnchors.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/config/TrustAnchors.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.config;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/rest/AuthToken.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/rest/AuthToken.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.rest;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/rest/SdoConstants.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/rest/SdoConstants.java
@@ -1,16 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.rest;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/rest/SdoUriComponentsBuilder.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/rest/SdoUriComponentsBuilder.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.rest;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/Aes128KeyFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/Aes128KeyFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -20,7 +7,6 @@ import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/Aes256KeyFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/Aes256KeyFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -20,7 +7,6 @@ import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/AsymKexCodec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/AsymKexCodec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/BouncyCastleSupplier.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/BouncyCastleSupplier.java
@@ -1,22 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
 import java.security.Provider;
 import java.util.function.Supplier;
-
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/CryptoLevel.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/CryptoLevel.java
@@ -1,26 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
 import java.security.PublicKey;
 import java.util.function.Function;
-
 import javax.crypto.SecretKey;
-
 import org.sdo.iotplatformsdk.common.protocol.types.DigestType;
 import org.sdo.iotplatformsdk.common.protocol.types.KeyExchangeType;
 import org.sdo.iotplatformsdk.common.protocol.types.MacType;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/CryptoLevel11.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/CryptoLevel11.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -23,9 +10,7 @@ import java.security.PublicKey;
 import java.security.interfaces.ECKey;
 import java.util.Set;
 import java.util.function.Function;
-
 import javax.crypto.SecretKey;
-
 import org.sdo.iotplatformsdk.common.protocol.types.DigestType;
 import org.sdo.iotplatformsdk.common.protocol.types.KeyExchangeType;
 import org.sdo.iotplatformsdk.common.protocol.types.MacType;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/CryptoLevel112.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/CryptoLevel112.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -23,9 +10,7 @@ import java.security.PublicKey;
 import java.security.interfaces.ECKey;
 import java.util.Set;
 import java.util.function.Function;
-
 import javax.crypto.SecretKey;
-
 import org.sdo.iotplatformsdk.common.protocol.types.DigestType;
 import org.sdo.iotplatformsdk.common.protocol.types.KeyExchangeType;
 import org.sdo.iotplatformsdk.common.protocol.types.MacType;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/CryptoLevels.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/CryptoLevels.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
 import java.util.Optional;
 import java.util.Set;
-
 import org.sdo.iotplatformsdk.common.protocol.types.MacType;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/DigestService.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/DigestService.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
-
 import org.sdo.iotplatformsdk.common.protocol.types.HashDigest;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/Hmac256KeyFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/Hmac256KeyFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -20,7 +7,6 @@ import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/Hmac384KeyFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/Hmac384KeyFactory.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
 import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/KeyMaterialFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/KeyMaterialFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -21,10 +8,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
-
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 
 class KeyMaterialFactory {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/MacService.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/MacService.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
-
 import org.sdo.iotplatformsdk.common.protocol.types.HashMac;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/SessionEncryptionKeyFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/SessionEncryptionKeyFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -21,9 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-
 import javax.crypto.SecretKey;
-
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 
 abstract class SessionEncryptionKeyFactory {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/SessionVerificationKeyFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/SessionVerificationKeyFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -21,9 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-
 import javax.crypto.SecretKey;
-
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 
 abstract class SessionVerificationKeyFactory {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/SignatureService.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/SignatureService.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
 import java.util.concurrent.Future;
-
 import org.sdo.iotplatformsdk.common.protocol.types.SignatureBlock;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/SignatureServiceFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/SignatureServiceFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/Signatures.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/Signatures.java
@@ -1,16 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -24,7 +13,6 @@ import java.security.SignatureException;
 import java.security.interfaces.ECKey;
 import java.security.interfaces.RSAKey;
 import java.security.spec.AlgorithmParameterSpec;
-
 import org.sdo.iotplatformsdk.common.protocol.types.EpidKey;
 
 public abstract class Signatures {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/SimpleDigestService.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/SimpleDigestService.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -22,7 +9,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Objects;
-
 import org.sdo.iotplatformsdk.common.protocol.types.DigestType;
 import org.sdo.iotplatformsdk.common.protocol.types.HashDigest;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/SimpleMacService.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/SimpleMacService.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -22,10 +9,8 @@ import java.nio.channels.ReadableByteChannel;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Objects;
-
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-
 import org.sdo.iotplatformsdk.common.protocol.types.HashMac;
 import org.sdo.iotplatformsdk.common.protocol.types.MacType;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/CbcIvParameterSpec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/CbcIvParameterSpec.java
@@ -1,26 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.cipher;
 
 import java.security.SecureRandom;
-
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
-
 import org.sdo.iotplatformsdk.common.protocol.rest.SdoConstants;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/CtrIvParameterSpec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/CtrIvParameterSpec.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.cipher;
 
@@ -20,10 +7,8 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.security.SecureRandom;
-
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
-
 import org.sdo.iotplatformsdk.common.protocol.rest.SdoConstants;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2Cipher.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2Cipher.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.cipher;
 
 import java.nio.ByteBuffer;
-
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2CipherContext.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2CipherContext.java
@@ -1,16 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.cipher;
 
@@ -24,12 +13,10 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
-
 import javax.crypto.Cipher;
 import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
-
 import org.bouncycastle.util.Arrays;
 import org.sdo.iotplatformsdk.common.protocol.codecs.CipherTextCodec;
 import org.sdo.iotplatformsdk.common.protocol.rest.SdoConstants;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2CipherFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2CipherFactory.java
@@ -1,16 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.cipher;
 
@@ -19,12 +8,10 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
-
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
-
 import org.sdo.iotplatformsdk.common.protocol.rest.SdoConstants;
 import org.sdo.iotplatformsdk.common.protocol.types.CipherBlockMode;
 import org.sdo.iotplatformsdk.common.protocol.types.MessageType;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2CipherMacFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2CipherMacFactory.java
@@ -1,24 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.cipher;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-
 import javax.crypto.Mac;
-
 import org.sdo.iotplatformsdk.common.protocol.rest.SdoConstants;
 import org.sdo.iotplatformsdk.common.protocol.types.MacType;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2IvParameterSpec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2IvParameterSpec.java
@@ -1,27 +1,12 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.cipher;
 
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
-
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
-
 import org.sdo.iotplatformsdk.common.protocol.rest.SdoConstants;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2IvParameterSpecFactory.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2IvParameterSpecFactory.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.cipher;
 
 import java.security.SecureRandom;
-
 import org.sdo.iotplatformsdk.common.protocol.types.CipherBlockMode;
 
 public final class To2IvParameterSpecFactory {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/keyexchange/AsymmetricKeyExchange.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/keyexchange/AsymmetricKeyExchange.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.keyexchange;
 
@@ -20,7 +7,6 @@ import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.security.AsymKexCodec;
 import org.sdo.iotplatformsdk.common.protocol.types.KeyExchangeType;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/keyexchange/DiffieHellmanKeyExchange.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/keyexchange/DiffieHellmanKeyExchange.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.keyexchange;
 
@@ -34,12 +21,10 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.Objects;
-
 import javax.crypto.KeyAgreement;
 import javax.crypto.interfaces.DHPublicKey;
 import javax.crypto.spec.DHParameterSpec;
 import javax.crypto.spec.DHPublicKeySpec;
-
 import org.bouncycastle.crypto.agreement.DHStandardGroups;
 import org.bouncycastle.crypto.params.DHParameters;
 import org.sdo.iotplatformsdk.common.protocol.types.KeyExchangeType;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/keyexchange/EcdhKeyExchange.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/keyexchange/EcdhKeyExchange.java
@@ -1,16 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.keyexchange;
 
@@ -42,9 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
-
 import javax.crypto.KeyAgreement;
-
 import org.sdo.iotplatformsdk.common.protocol.types.KeyExchangeType;
 import org.sdo.iotplatformsdk.common.protocol.types.Keys;
 import org.sdo.iotplatformsdk.common.protocol.util.BigIntegers;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/keyexchange/KeyExchange.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/keyexchange/KeyExchange.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.keyexchange;
 
@@ -22,12 +9,10 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
-
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.ShortBufferException;
-
 import org.sdo.iotplatformsdk.common.protocol.types.KeyExchangeType;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/pkix/SdoCertPathValidator.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/security/pkix/SdoCertPathValidator.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.pkix;
 
@@ -31,7 +18,6 @@ import java.security.cert.TrustAnchor;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
 import org.slf4j.LoggerFactory;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/CipherAlgorithm.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/CipherAlgorithm.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/CipherBlockMode.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/CipherBlockMode.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/CipherPadding.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/CipherPadding.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/CipherText.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/CipherText.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import java.nio.ByteBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/CipherType.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/CipherType.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/DeviceState.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/DeviceState.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/DigestType.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/DigestType.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/EncryptedMessage.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/EncryptedMessage.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey10.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey10.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey11.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey11.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey20.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey20.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/EpidSignatureParameterSpec.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/EpidSignatureParameterSpec.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import java.nio.ByteBuffer;
 import java.security.spec.AlgorithmParameterSpec;
-
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 
 public class EpidSignatureParameterSpec implements AlgorithmParameterSpec {

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Hash.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Hash.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/HashDigest.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/HashDigest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -22,7 +9,6 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.util.Arrays;
 import java.util.Objects;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.HashDigestCodec.HashDigestDecoder;
 import org.sdo.iotplatformsdk.common.protocol.codecs.HashDigestCodec.HashDigestEncoder;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/HashMac.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/HashMac.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -22,7 +9,6 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.util.Arrays;
 import java.util.Objects;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.HashMacCodec.HashMacDecoder;
 import org.sdo.iotplatformsdk.common.protocol.codecs.HashMacCodec.HashMacEncoder;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/IpAddress.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/IpAddress.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -26,7 +13,6 @@ import java.net.InetAddress;
 import java.nio.CharBuffer;
 import java.util.Base64;
 import java.util.Objects;
-
 import org.sdo.iotplatformsdk.common.protocol.types.UInt.UInt8;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/KeyEncoding.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/KeyEncoding.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/KeyExchangeType.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/KeyExchangeType.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/KeyType.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/KeyType.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Keys.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Keys.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -31,7 +18,6 @@ import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.ASN1Sequence;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/MacType.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/MacType.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Message.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Message.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/MessageType.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/MessageType.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Nonce.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Nonce.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/OwnershipProxy.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/OwnershipProxy.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/OwnershipProxyEntry.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/OwnershipProxyEntry.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/OwnershipProxyHeader.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/OwnershipProxyHeader.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/PreServiceInfo.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/PreServiceInfo.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/PreServiceInfoEntry.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/PreServiceInfoEntry.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/RendezvousInfo.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/RendezvousInfo.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/RendezvousInstr.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/RendezvousInstr.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -38,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
 import org.sdo.iotplatformsdk.common.protocol.types.UInt.UInt16;
 import org.sdo.iotplatformsdk.common.protocol.types.UInt.UInt32;
 import org.sdo.iotplatformsdk.common.protocol.types.UInt.UInt8;

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/SdoError.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/SdoError.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Objects;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.SdoErrorCodec;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/SdoErrorCode.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/SdoErrorCode.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/SdoProtocolException.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/SdoProtocolException.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import java.io.IOException;
 import java.io.StringWriter;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.SdoErrorCodec;
 
 @SuppressWarnings("serial")

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/ServiceInfo.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/ServiceInfo.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/ServiceInfoEntry.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/ServiceInfoEntry.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/SigInfo.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/SigInfo.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import java.nio.ByteBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/SignatureBlock.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/SignatureBlock.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -20,7 +7,6 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.PublicKey;
 import java.util.Objects;
-
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 
 /**

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/SignatureType.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/SignatureType.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Strings.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Strings.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To0AcceptOwner.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To0AcceptOwner.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To0Hello.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To0Hello.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To0HelloAck.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To0HelloAck.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To0OwnerSign.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To0OwnerSign.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To0OwnerSignTo0d.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To0OwnerSignTo0d.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To1SdoRedirect.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To1SdoRedirect.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2CipherHashMac.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2CipherHashMac.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -21,7 +8,6 @@ import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.util.Arrays;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.To2CipherHashMacCodec.To2CipherHashMacDecoder;
 import org.sdo.iotplatformsdk.common.protocol.codecs.To2CipherHashMacCodec.To2CipherHashMacEncoder;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2Done.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2Done.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2Done2.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2Done2.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2GetNextDeviceServiceInfo.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2GetNextDeviceServiceInfo.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2GetNextOwnerServiceInfo.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2GetNextOwnerServiceInfo.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2GetOpNextEntry.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2GetOpNextEntry.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2HelloDevice.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2HelloDevice.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2NextDeviceServiceInfo.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2NextDeviceServiceInfo.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2OpNextEntry.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2OpNextEntry.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2OwnerServiceInfo.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2OwnerServiceInfo.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2ProveDevice.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2ProveDevice.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2ProveOpHdr.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2ProveOpHdr.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2SetupDevice.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2SetupDevice.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2SetupDeviceNoh.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/To2SetupDeviceNoh.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/UInt.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/UInt.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Uuids.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Uuids.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Version.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/types/Version.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/util/BigIntegers.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/util/BigIntegers.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.util;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/util/Buffers.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/util/Buffers.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.util;
 

--- a/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/util/Destroyer.java
+++ b/common/protocol/src/main/java/org/sdo/iotplatformsdk/common/protocol/util/Destroyer.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.util;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/AppIdCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/AppIdCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -22,7 +9,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/CertPathCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/CertPathCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
 import java.security.cert.CertPath;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/CertificateCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/CertificateCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -26,7 +13,6 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/CipherTextCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/CipherTextCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -21,7 +8,6 @@ import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/CipherTypeCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/CipherTypeCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/EncryptedMessageCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/EncryptedMessageCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -21,7 +8,6 @@ import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/InetAddressCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/InetAddressCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -22,7 +9,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/IvDataCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/IvDataCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -22,7 +9,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/KexParamCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/KexParamCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -22,7 +9,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/KeyExchangeTypeCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/KeyExchangeTypeCodecTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/KeyTypeCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/KeyTypeCodecTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/OwnershipProxyEntryCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/OwnershipProxyEntryCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -23,7 +10,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkEpidCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkEpidCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkNullCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkNullCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -23,7 +10,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkRmeCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkRmeCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkX509CodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/PkX509CodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -24,7 +11,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/PreServiceInfoCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/PreServiceInfoCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
 import java.security.NoSuchAlgorithmException;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/PublicKeyCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/PublicKeyCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -23,7 +10,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/SdoErrorCodeCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/SdoErrorCodeCodecTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/SdoErrorCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/SdoErrorCodecTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/ServiceInfoCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/ServiceInfoCodecTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/SigInfoCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/SigInfoCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/SignatureBlockCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/SignatureBlockCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -22,7 +9,6 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/SignatureTypeCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/SignatureTypeCodecTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/StringCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/StringCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -22,7 +9,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0AcceptOwnerCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0AcceptOwnerCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
 import java.time.Duration;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0HelloAckCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0HelloAckCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0HelloCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To0HelloCodecTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To1SdoRedirectCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To1SdoRedirectCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -21,7 +8,6 @@ import java.io.StringWriter;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2Done2CodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2Done2CodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2DoneCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2DoneCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -21,7 +8,6 @@ import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2GetNextDeviceServiceInfoCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2GetNextDeviceServiceInfoCodecTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2GetNextOwnerServiceInfoCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2GetNextOwnerServiceInfoCodecTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2GetOpNextEntryCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2GetOpNextEntryCodecTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2HelloDeviceCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2HelloDeviceCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -22,7 +9,6 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.SecureRandom;
 import java.util.UUID;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2NextDeviceServiceInfoCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2NextDeviceServiceInfoCodecTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2OpNextEntryCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2OpNextEntryCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -22,7 +9,6 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2OwnerServiceInfoCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2OwnerServiceInfoCodecTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2ProveDeviceCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2ProveDeviceCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -22,7 +9,6 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.SecureRandom;
 import java.util.UUID;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2ProveOpHdrCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2ProveOpHdrCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -21,7 +8,6 @@ import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2SetupDeviceCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2SetupDeviceCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -21,7 +8,6 @@ import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.security.NoSuchAlgorithmException;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2SetupDeviceNohCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/To2SetupDeviceNohCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -21,7 +8,6 @@ import java.io.StringWriter;
 import java.nio.CharBuffer;
 import java.security.SecureRandom;
 import java.util.UUID;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/UriCodecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/codecs/UriCodecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.codecs;
 
@@ -21,7 +8,6 @@ import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/config/EpidOptionBeanTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/config/EpidOptionBeanTest.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.config;
 
 import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.config.EpidOptionBean;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/config/SecureRandomFactoryBeanTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/config/SecureRandomFactoryBeanTest.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.config;
 
 import java.io.IOException;
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/config/SslContextFactoryBeanTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/config/SslContextFactoryBeanTest.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.config;
 
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/config/TrustAnchorsTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/config/TrustAnchorsTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.config;
 
@@ -21,7 +8,6 @@ import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/rest/AuthTokenTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/rest/AuthTokenTest.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.rest;
 
 import java.io.IOException;
 import java.util.UUID;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.rest.AuthToken;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/rest/SdoUriComponentBuilderTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/rest/SdoUriComponentBuilderTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.rest;
 
@@ -20,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.URI;
-
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.MessageType;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/Aes128KeyFactoryTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/Aes128KeyFactoryTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.security.Aes128KeyFactory;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/Aes256KeyFactoryTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/Aes256KeyFactoryTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.security.Aes256KeyFactory;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/CryptoLevel112Test.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/CryptoLevel112Test.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/CryptoLevel11Test.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/CryptoLevel11Test.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/Hmac256KeyFactoryTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/Hmac256KeyFactoryTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.security.Hmac256KeyFactory;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/Hmac384KeyFactoryTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/Hmac384KeyFactoryTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.security.Hmac384KeyFactory;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/SimpleDigestServiceTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/SimpleDigestServiceTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -24,7 +11,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.security.SimpleDigestService;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/SimpleMacServiceTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/SimpleMacServiceTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security;
 
@@ -24,7 +11,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.security.SimpleMacService;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2CipherContextTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/cipher/To2CipherContextTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.cipher;
 
@@ -23,9 +10,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-
 import javax.crypto.SecretKey;
-
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/keyexchange/DiffieHellmanKeyExchangeTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/keyexchange/DiffieHellmanKeyExchangeTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.keyexchange;
 
@@ -20,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.security.keyexchange.DiffieHellmanKeyExchange.Group14;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/keyexchange/EcdhKeyExchangeTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/keyexchange/EcdhKeyExchangeTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.keyexchange;
 
@@ -21,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.nio.ByteBuffer;
 import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.security.keyexchange.EcdhKeyExchange;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/pkix/SdoCertPathValidatorTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/security/pkix/SdoCertPathValidatorTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.security.pkix;
 
@@ -27,7 +14,6 @@ import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.HashSet;
 import java.util.Set;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/CipherTypeTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/CipherTypeTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/EncryptedMessageTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/EncryptedMessageTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.CipherText;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey10Test.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey10Test.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey11Test.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey11Test.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey20Test.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKey20Test.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKeyTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/EpidKeyTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/EpidSignatureParameterSpecTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/EpidSignatureParameterSpecTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -20,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.EpidSignatureParameterSpec;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/HashDigestTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/HashDigestTest.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.HashDigest;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/HashMacTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/HashMacTest.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.HashMac;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/IpAddressTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/IpAddressTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.CharBuffer;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.IpAddress;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/KeysTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/KeysTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -23,7 +10,6 @@ import java.io.StringReader;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.util.Arrays;
-
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/NonceTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/NonceTest.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import java.nio.CharBuffer;
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.Nonce;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/OwnershipProxyHeaderTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/OwnershipProxyHeaderTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -23,7 +10,6 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.util.UUID;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.HashDigest;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/RendezvousInstrTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/RendezvousInstrTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import java.net.InetAddress;
 import java.nio.CharBuffer;
 import java.time.Duration;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.RendezvousInstr;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/SdoErrorTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/SdoErrorTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/SigInfoTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/SigInfoTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.SigInfo;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/SignatureBlockTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/SignatureBlockTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -24,7 +11,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To0AcceptOwnerTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To0AcceptOwnerTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Duration;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.To0AcceptOwner;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To0OwnerSignTo0dTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To0OwnerSignTo0dTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -20,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.security.SecureRandom;
 import java.time.Duration;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.Nonce;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To1SdoRedirectTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To1SdoRedirectTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -20,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.HashDigest;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2Done2Test.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2Done2Test.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.Nonce;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2DoneTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2DoneTest.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.security.SecureRandom;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.HashMac;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2GetNextDeviceServiceInfoTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2GetNextDeviceServiceInfoTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2GetNextOwnerServiceInfoTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2GetNextOwnerServiceInfoTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2GetOpNextEntryTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2GetOpNextEntryTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2NextDeviceServiceInfoTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2NextDeviceServiceInfoTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2OwnerServiceInfoTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2OwnerServiceInfoTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2SetupDeviceNohTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2SetupDeviceNohTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 
@@ -20,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.security.SecureRandom;
 import java.util.UUID;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.protocol.types.Nonce;

--- a/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2SetupDeviceTest.java
+++ b/common/protocol/src/test/java/org/sdo/iotplatformsdk/common/protocol/types/To2SetupDeviceTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.protocol.types;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/CipherOperation.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/CipherOperation.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/DeviceCryptoInfo.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/DeviceCryptoInfo.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/DeviceState.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/DeviceState.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/DeviceStateType.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/DeviceStateType.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/Iso8061Timestamp.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/Iso8061Timestamp.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/Message41Store.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/Message41Store.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/Message45Store.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/Message45Store.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/Message47Store.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/Message47Store.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/MessageEncoding.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/MessageEncoding.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/ModuleMessage.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/ModuleMessage.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucher.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucher.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherEntry.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherEntry.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherEntryBodyObject.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherEntryBodyObject.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherHeader.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherHeader.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 import java.util.Optional;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/ProtocolError.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/ProtocolError.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/RendezvousInstruction.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/RendezvousInstruction.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/SetupInfoResponse.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/SetupInfoResponse.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/SignatureResponse.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/SignatureResponse.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/SviMarshalled.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/SviMarshalled.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/SviMessage.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/SviMessage.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/SviMessageType.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/SviMessageType.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/To0Request.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/To0Request.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/To2DeviceSessionInfo.java
+++ b/common/rest/src/main/java/org/sdo/iotplatformsdk/common/rest/To2DeviceSessionInfo.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/DeviceStateTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/DeviceStateTest.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import java.io.IOException;
 import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.rest.DeviceState;

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/Iso8061TimestampTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/Iso8061TimestampTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/ModuleMessageTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/ModuleMessageTest.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.rest.ModuleMessage;

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherEntryObjectTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherEntryObjectTest.java
@@ -1,29 +1,14 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import java.io.IOException;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.sdo.iotplatformsdk.common.rest.OwnerVoucherEntryBodyObject;
-
 
 class OwnerVoucherEntryObjectTest {
 

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherEntryTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherEntryTest.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import java.io.IOException;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherHeaderTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherHeaderTest.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import java.io.IOException;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/OwnerVoucherTest.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import java.io.IOException;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/ProtocolErrorTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/ProtocolErrorTest.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.rest.ProtocolError;

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/RendezvousInstructionTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/RendezvousInstructionTest.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.rest.RendezvousInstruction;

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/SetupInfoResponseTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/SetupInfoResponseTest.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import java.io.IOException;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/SignatureResponseTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/SignatureResponseTest.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.rest.SignatureResponse;

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/SviMessageTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/SviMessageTest.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.rest.SviMessage;

--- a/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/To0RequestTest.java
+++ b/common/rest/src/test/java/org/sdo/iotplatformsdk/common/rest/To0RequestTest.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.common.rest;
 
 import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.common.rest.To0Request;

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/config/FsApplication.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/config/FsApplication.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.fsimpl.config;
 
 import java.util.Collections;
-
 import org.springframework.boot.Banner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/config/FsConfiguration.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/config/FsConfiguration.java
@@ -1,22 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.fsimpl.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-
 import org.sdo.iotplatformsdk.ocs.fsimpl.fs.FsOcsContractImpl;
 import org.sdo.iotplatformsdk.ocs.fsimpl.rest.FsHealthController;
 import org.sdo.iotplatformsdk.ocs.fsimpl.rest.OcsRestController;

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/BouncyCastleSupplier.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/BouncyCastleSupplier.java
@@ -1,22 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.fsimpl.fs;
 
 import java.security.Provider;
 import java.util.function.Supplier;
-
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 public class BouncyCastleSupplier implements Supplier<Provider> {

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsDataManager.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsDataManager.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.fsimpl.fs;
 
@@ -24,7 +11,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
-
 import org.sdo.iotplatformsdk.ocs.services.DataManager;
 import org.sdo.iotplatformsdk.ocs.services.DataObject;
 

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsDataObject.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsDataObject.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.fsimpl.fs;
 
@@ -20,7 +7,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
 import org.sdo.iotplatformsdk.ocs.services.DataObject;
 
 /**

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsDataRangeObject.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsDataRangeObject.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.fsimpl.fs;
 

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsOcsContractImpl.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsOcsContractImpl.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.fsimpl.fs;
 
@@ -22,7 +9,6 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -66,10 +52,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-
 import javax.crypto.Cipher;
 import javax.security.auth.DestroyFailedException;
-
 import org.bouncycastle.util.encoders.Hex;
 import org.sdo.iotplatformsdk.common.rest.CipherOperation;
 import org.sdo.iotplatformsdk.common.rest.DeviceCryptoInfo;

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsPropertiesLoader.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsPropertiesLoader.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.fsimpl.fs;
 
@@ -20,7 +7,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/Signatures.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/Signatures.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.fsimpl.fs;
 

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/FsHealthController.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/FsHealthController.java
@@ -1,21 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.fsimpl.rest;
 
 import java.sql.Timestamp;
-
 import org.sdo.iotplatformsdk.ocs.fsimpl.fs.FsPropertiesLoader;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/FsRestClient.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/FsRestClient.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.fsimpl.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -30,13 +16,11 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.time.Duration;
-
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
-
 import org.sdo.iotplatformsdk.common.rest.To0Request;
 import org.sdo.iotplatformsdk.ocs.fsimpl.fs.FsPropertiesLoader;
 import org.slf4j.Logger;

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/OcsRestController.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/OcsRestController.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.fsimpl.rest;
 
 import java.io.FileNotFoundException;
-
 import org.sdo.iotplatformsdk.common.rest.DeviceState;
 import org.sdo.iotplatformsdk.common.rest.ModuleMessage;
 import org.sdo.iotplatformsdk.common.rest.OwnerVoucher;
@@ -41,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-
 import reactor.core.publisher.Mono;
 
 @RestController

--- a/ocs/libocs/src/main/java/org/sdo/iotplatformsdk/ocs/services/DataManager.java
+++ b/ocs/libocs/src/main/java/org/sdo/iotplatformsdk/ocs/services/DataManager.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.services;
 

--- a/ocs/libocs/src/main/java/org/sdo/iotplatformsdk/ocs/services/DataObject.java
+++ b/ocs/libocs/src/main/java/org/sdo/iotplatformsdk/ocs/services/DataObject.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.services;
 

--- a/ocs/libocs/src/main/java/org/sdo/iotplatformsdk/ocs/services/OcsRestContract.java
+++ b/ocs/libocs/src/main/java/org/sdo/iotplatformsdk/ocs/services/OcsRestContract.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ocs.services;
 

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/Epid11eB.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/Epid11eB.java
@@ -1,23 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/Epid20eB.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/Epid20eB.java
@@ -1,22 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidConstants.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidConstants.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidGroupPublicKey.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidGroupPublicKey.java
@@ -1,23 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 
 import java.io.IOException;
-
 import javax.xml.bind.DatatypeConverter;
-
 import org.bouncycastle.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidLib.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidLib.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidOnlineMaterial.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidOnlineMaterial.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidOnlineVerifier.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidOnlineVerifier.java
@@ -1,16 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidSecurityProvider.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidSecurityProvider.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 
@@ -22,7 +9,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.Security;
 import java.util.Arrays;
-
 import org.sdo.iotplatformsdk.common.protocol.config.SecureRandomFactory;
 import org.sdo.iotplatformsdk.common.protocol.config.SslContextFactory;
 import org.slf4j.Logger;

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidSigRl.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidSigRl.java
@@ -1,23 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 
 import java.io.IOException;
-
 import javax.xml.bind.DatatypeConverter;
-
 import org.bouncycastle.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidSignatureSpi.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidSignatureSpi.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 
@@ -26,7 +13,6 @@ import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.SignatureSpi;
 import java.security.spec.AlgorithmParameterSpec;
-
 import org.sdo.iotplatformsdk.common.protocol.types.EpidKey;
 import org.sdo.iotplatformsdk.common.protocol.types.EpidSignatureParameterSpec;
 import org.sdo.iotplatformsdk.common.protocol.types.Nonce;

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidSignedMaterial.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidSignedMaterial.java
@@ -1,23 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-
 import org.bouncycastle.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidUtils.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidUtils.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-
 import org.bouncycastle.util.Arrays;
 
 /**

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/SigInfoResponder.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/SigInfoResponder.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeoutException;
-
 import org.sdo.iotplatformsdk.common.protocol.types.SigInfo;
 import org.sdo.iotplatformsdk.common.protocol.util.Buffers;
 

--- a/ops/epid/src/test/java/org/sdo/iotplatformsdk/ops/epid/EpidUtilsTest.java
+++ b/ops/epid/src/test/java/org/sdo/iotplatformsdk/ops/epid/EpidUtilsTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.epid;
 

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/KeyExchangeDecoder.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/KeyExchangeDecoder.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
 import java.security.SecureRandom;
 import java.util.Objects;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.security.AsymKexCodec;
 import org.sdo.iotplatformsdk.common.protocol.security.keyexchange.AsymmetricKeyExchange;
 import org.sdo.iotplatformsdk.common.protocol.security.keyexchange.DiffieHellmanKeyExchange;

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message255Handler.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message255Handler.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.nio.CharBuffer;
 import java.util.Objects;
 import java.util.Optional;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.OwnershipProxyCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.SdoErrorCodec;
 import org.sdo.iotplatformsdk.common.protocol.types.MessageType;

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message40Handler.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message40Handler.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -24,7 +11,6 @@ import java.security.SecureRandom;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.ByteArrayCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.CipherTypeCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.KexParamCodec;

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message42Handler.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message42Handler.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
 import java.util.Objects;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.OwnershipProxyCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.PublicKeyCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.SignatureBlockCodec;

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message44Handler.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message44Handler.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -33,7 +20,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.ByteArrayCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.EncryptedMessageCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.KexParamCodec;

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message46Handler.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message46Handler.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -27,7 +14,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Objects;
 import java.util.Set;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.ByteArrayCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.EncryptedMessageCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.KexParamCodec;

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message48Handler.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message48Handler.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -26,7 +13,6 @@ import java.security.SecureRandom;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.ByteArrayCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.EncryptedMessageCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.KexParamCodec;

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message50Handler.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/Message50Handler.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -26,7 +13,6 @@ import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.ByteArrayCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.EncryptedMessageCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.KexParamCodec;

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/OwnerEvent.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/OwnerEvent.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/OwnerEventHandler.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/OwnerEventHandler.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/OwnerResaleSupport.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/OwnerResaleSupport.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/OwnerServiceInfoHandler.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/OwnerServiceInfoHandler.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -28,7 +15,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.ServiceInfoCodec;
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfo;
 import org.sdo.iotplatformsdk.ops.serviceinfo.ServiceInfoMarshaller;

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/SessionStorage.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/SessionStorage.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
 import java.io.IOException;
 import java.time.Duration;
-
 import org.sdo.iotplatformsdk.common.rest.To2DeviceSessionInfo;
 
 public interface SessionStorage {

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/SetupDeviceService.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/SetupDeviceService.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.RendezvousInfo;
 
 /**

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2BeginEvent.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2BeginEvent.java
@@ -1,16 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2CipherContextFactory.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2CipherContextFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -25,13 +12,11 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
-
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.ShortBufferException;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.ByteArrayCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.CipherTypeCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.KeyExchangeTypeCodec;

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2EndEvent.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2EndEvent.java
@@ -1,16 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2ErrorEvent.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2ErrorEvent.java
@@ -1,16 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2ProvingOwner.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2ProvingOwner.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
 import java.nio.ByteBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.security.keyexchange.KeyExchange;
 import org.sdo.iotplatformsdk.common.protocol.types.CipherType;
 import org.sdo.iotplatformsdk.common.protocol.types.Nonce;

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2ReceivingDeviceServiceInfo.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2ReceivingDeviceServiceInfo.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2SendingOwnerServiceInfo.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2SendingOwnerServiceInfo.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
 import java.util.Iterator;
 import java.util.function.Supplier;
-
 import org.sdo.iotplatformsdk.common.protocol.security.cipher.To2CipherContext;
 import org.sdo.iotplatformsdk.common.protocol.types.OwnershipProxy;
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfo;

--- a/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2Session.java
+++ b/ops/libops/src/main/java/org/sdo/iotplatformsdk/ops/to2library/To2Session.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 

--- a/ops/libops/src/test/java/org/sdo/iotplatformsdk/ops/to2library/Message255HandlerTest.java
+++ b/ops/libops/src/test/java/org/sdo/iotplatformsdk/ops/to2library/Message255HandlerTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -22,9 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.nio.ByteBuffer;
 import java.nio.LongBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import javax.xml.bind.DatatypeConverter;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/ops/libops/src/test/java/org/sdo/iotplatformsdk/ops/to2library/Message40HandlerTest.java
+++ b/ops/libops/src/test/java/org/sdo/iotplatformsdk/ops/to2library/Message40HandlerTest.java
@@ -1,16 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -24,7 +13,6 @@ import java.security.SecureRandom;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/ops/libops/src/test/java/org/sdo/iotplatformsdk/ops/to2library/Message42HandlerTest.java
+++ b/ops/libops/src/test/java/org/sdo/iotplatformsdk/ops/to2library/Message42HandlerTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -21,7 +8,6 @@ import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.UUID;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/ops/libops/src/test/java/org/sdo/iotplatformsdk/ops/to2library/Message44HandlerTest.java
+++ b/ops/libops/src/test/java/org/sdo/iotplatformsdk/ops/to2library/Message44HandlerTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -27,7 +14,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/ops/libops/src/test/java/org/sdo/iotplatformsdk/ops/to2library/Message46HandlerTest.java
+++ b/ops/libops/src/test/java/org/sdo/iotplatformsdk/ops/to2library/Message46HandlerTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -25,7 +12,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/ops/libops/src/test/java/org/sdo/iotplatformsdk/ops/to2library/Message48HandlerTest.java
+++ b/ops/libops/src/test/java/org/sdo/iotplatformsdk/ops/to2library/Message48HandlerTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.to2library;
 
@@ -21,7 +8,6 @@ import java.security.SecureRandom;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/config/OpsApplication.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/config/OpsApplication.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.config;
 
 import java.util.Collections;
-
 import org.springframework.boot.Banner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/config/OpsConfiguration.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/config/OpsConfiguration.java
@@ -1,26 +1,13 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.config;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-
 import java.util.HashSet;
 import java.util.concurrent.Executors;
-
 import org.sdo.iotplatformsdk.common.protocol.config.EpidOptionBean;
 import org.sdo.iotplatformsdk.common.protocol.config.ObjectFactory;
 import org.sdo.iotplatformsdk.common.protocol.config.OwnershipProxyStorage;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsAsciiSequence.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsAsciiSequence.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.ops.rest.RestClient;
 
 /**

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsAsymKexCodec.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsAsymKexCodec.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
 import java.nio.ByteBuffer;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.security.AsymKexCodec;
 import org.sdo.iotplatformsdk.common.rest.CipherOperation;
 import org.sdo.iotplatformsdk.ops.rest.RestClient;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsBase64Sequence.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsBase64Sequence.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
@@ -21,7 +8,6 @@ import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.ops.rest.RestClient;
 
 /**

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsCharSequence.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsCharSequence.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.ops.rest.RestClient;
 
 public abstract class OpsCharSequence implements CharSequence {

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsOwnerEventHandler.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsOwnerEventHandler.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
 import java.util.Optional;
-
 import org.sdo.iotplatformsdk.common.rest.DeviceState;
 import org.sdo.iotplatformsdk.common.rest.DeviceStateType;
 import org.sdo.iotplatformsdk.common.rest.Iso8061Timestamp;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsOwnerEventHandlerFactory.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsOwnerEventHandlerFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsPropertiesLoader.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsPropertiesLoader.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
@@ -20,7 +7,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsProxyStorage.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsProxyStorage.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
@@ -20,7 +7,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.OwnershipProxyCodec;
 import org.sdo.iotplatformsdk.common.protocol.config.OwnershipProxyStorage;
 import org.sdo.iotplatformsdk.common.protocol.types.OwnershipProxy;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsResaleSupport.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsResaleSupport.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsServiceInfoModule.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsServiceInfoModule.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
@@ -21,7 +8,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.PreServiceInfoEntry;
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfo;
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfoEntry;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsSessionStorage.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsSessionStorage.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
 import java.io.IOException;
 import java.time.Duration;
-
 import org.sdo.iotplatformsdk.common.rest.To2DeviceSessionInfo;
 import org.sdo.iotplatformsdk.ops.rest.RestClient;
 import org.sdo.iotplatformsdk.ops.to2library.SessionStorage;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsSessionStorageFactory.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsSessionStorageFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsSetupDeviceServiceInfo.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsSetupDeviceServiceInfo.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
@@ -21,7 +8,6 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.RendezvousInfo;
 import org.sdo.iotplatformsdk.common.protocol.types.RendezvousInstr;
 import org.sdo.iotplatformsdk.common.rest.RendezvousInstruction;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsSignatureServiceFactory.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsSignatureServiceFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
@@ -25,7 +12,6 @@ import java.util.Base64;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
-
 import org.sdo.iotplatformsdk.common.protocol.security.SignatureService;
 import org.sdo.iotplatformsdk.common.protocol.security.SignatureServiceFactory;
 import org.sdo.iotplatformsdk.common.protocol.types.SignatureBlock;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/OpsControllerAdvice.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/OpsControllerAdvice.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.rest;
 

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/OpsCustomSslContextFactory.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/OpsCustomSslContextFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.rest;
 
@@ -20,13 +7,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.security.SecureRandom;
-
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
-
 import org.sdo.iotplatformsdk.common.protocol.config.SslContextFactory;
 import org.sdo.iotplatformsdk.ops.opsimpl.OpsPropertiesLoader;
 import org.slf4j.Logger;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/OpsHealthController.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/OpsHealthController.java
@@ -1,21 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.rest;
 
 import java.sql.Timestamp;
-
 import org.sdo.iotplatformsdk.ops.opsimpl.OpsPropertiesLoader;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/OpsTransferOwnershipController.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/OpsTransferOwnershipController.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.rest;
 
 import java.nio.CharBuffer;
 import java.util.concurrent.Callable;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.To2HelloDeviceCodec;
 import org.sdo.iotplatformsdk.common.protocol.rest.AuthToken;
 import org.sdo.iotplatformsdk.common.protocol.types.SdoProtocolException;

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/RestClient.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/RestClient.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.rest;
 

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/RestHeaderRequestInterceptor.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/rest/RestHeaderRequestInterceptor.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.rest;
 
 import java.io.IOException;
-
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;

--- a/ops/restimpl/src/test/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsOwnerEventHandlerTest.java
+++ b/ops/restimpl/src/test/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsOwnerEventHandlerTest.java
@@ -1,26 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
 import java.io.IOException;
 import java.nio.CharBuffer;
-
 import junit.framework.TestCase;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/ops/restimpl/src/test/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsProxyStorageTest.java
+++ b/ops/restimpl/src/test/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsProxyStorageTest.java
@@ -1,27 +1,12 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.UUID;
-
 import junit.framework.TestCase;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/ops/restimpl/src/test/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsResaleSupportTest.java
+++ b/ops/restimpl/src/test/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsResaleSupportTest.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
 import junit.framework.TestCase;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/ops/restimpl/src/test/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsServiceInfoModuleTest.java
+++ b/ops/restimpl/src/test/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsServiceInfoModuleTest.java
@@ -1,26 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
 import java.util.List;
 import java.util.UUID;
-
 import junit.framework.TestCase;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/ops/restimpl/src/test/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsSignatureServiceFactoryTest.java
+++ b/ops/restimpl/src/test/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsSignatureServiceFactoryTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.opsimpl;
 
@@ -22,9 +9,7 @@ import java.nio.CharBuffer;
 import java.util.Base64;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-
 import junit.framework.TestCase;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/PreServiceInfoMultiSource.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/PreServiceInfoMultiSource.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo;
 
 import java.util.List;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.PreServiceInfoEntry;
 
 /**

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/PreServiceInfoSink.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/PreServiceInfoSink.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo;
 

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/ServiceInfoMarshaller.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/ServiceInfoMarshaller.java
@@ -1,16 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo;
 
@@ -20,7 +9,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
-
 import org.sdo.iotplatformsdk.common.protocol.rest.SdoConstants;
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfo;
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfoEntry;
@@ -207,7 +195,7 @@ public final class ServiceInfoMarshaller {
             encodeLen = (((valueFitLen + 1) + 2) / 3) * 4;
             if ((packed + encodeLen) > mtulimit) {
               valueFitLen = valueFitLen - (valueFitLen % 4);
-              break;// if encoded length does not fit then done packing
+              break; // if encoded length does not fit then done packing
             }
             valueFitLen++;
             if (valueFitLen == valueRemaining) {

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/ServiceInfoModule.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/ServiceInfoModule.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo;
 

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/ServiceInfoMultiSink.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/ServiceInfoMultiSink.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo;
 
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfo;
 
 /**

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/ServiceInfoMultiSource.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/ServiceInfoMultiSource.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo;
 
 import java.util.List;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfoEntry;
 
 /**

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/ServiceInfoSink.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/ServiceInfoSink.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo;
 

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/ServiceInfoSource.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/ServiceInfoSource.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo;
 
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.function.Supplier;
-
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfoEntry;
 
 /**

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdodev/SdoDev.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdodev/SdoDev.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo.sdodev;
 

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdodev/SdoDevModuleDevice.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdodev/SdoDevModuleDevice.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo.sdodev;
 
 import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
-
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfoEntry;
 import org.sdo.iotplatformsdk.ops.serviceinfo.ServiceInfoSource;
 

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdosys/ExecSource.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdosys/ExecSource.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo.sdosys;
 
@@ -21,7 +8,6 @@ import java.util.Base64;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfoEntry;
 import org.sdo.iotplatformsdk.ops.serviceinfo.ServiceInfoMultiSource;
 

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdosys/FileBase64Sequence.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdosys/FileBase64Sequence.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo.sdosys;
 

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdosys/FileDownloadSource.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdosys/FileDownloadSource.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo.sdosys;
 
@@ -21,7 +8,6 @@ import java.util.Base64;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfoEntry;
 import org.sdo.iotplatformsdk.ops.serviceinfo.ServiceInfoMultiSource;
 

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdosys/SdoSys.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdosys/SdoSys.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo.sdosys;
 

--- a/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdosys/SdoSysModuleOwner.java
+++ b/ops/serviceinfo/src/main/java/org/sdo/iotplatformsdk/ops/serviceinfo/sdosys/SdoSysModuleOwner.java
@@ -1,25 +1,11 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.ops.serviceinfo.sdosys;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
-
 import org.sdo.iotplatformsdk.common.protocol.types.ServiceInfoEntry;
 import org.sdo.iotplatformsdk.ops.serviceinfo.ServiceInfoMultiSource;
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
   </parent>
 
   <properties>
-    <com.puppycrawl.tools.checkstyle.version>8.14</com.puppycrawl.tools.checkstyle.version>
     <com.fasterxml.jackson.version>2.10.3</com.fasterxml.jackson.version>
     <org.bouncycastle.version>1.64</org.bouncycastle.version>
     <org.apache.httpcomponents.version>4.5.12</org.apache.httpcomponents.version>
@@ -34,7 +33,7 @@
     <org.mockito.version>1.10.19</org.mockito.version>
     <junit-jupiter.version>5.6.1</junit-jupiter.version>
     <org.apache.maven.plugins.maven-checkstyle-plugin.version>
-      3.0.0
+      3.1.0
     </org.apache.maven.plugins.maven-checkstyle-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -278,13 +277,6 @@
         <version>
           ${org.apache.maven.plugins.maven-checkstyle-plugin.version}
         </version>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>${com.puppycrawl.tools.checkstyle.version}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>checkstyle-check</id>

--- a/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0ProxyStore.java
+++ b/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0ProxyStore.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0library;
 
 import java.io.IOException;
-
 import org.sdo.iotplatformsdk.common.protocol.types.OwnershipProxy;
 
 /**

--- a/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0ScheduledClientSession.java
+++ b/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0ScheduledClientSession.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0library;
 
@@ -20,7 +7,6 @@ import java.net.URI;
 import java.nio.CharBuffer;
 import java.time.Duration;
 import java.util.Iterator;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.SdoErrorCodec;
 import org.sdo.iotplatformsdk.common.protocol.types.MessageType;
 import org.sdo.iotplatformsdk.common.protocol.types.OwnershipProxy;

--- a/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0Scheduler.java
+++ b/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0Scheduler.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0library;
 
@@ -22,7 +9,6 @@ import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-
 import org.sdo.iotplatformsdk.common.protocol.config.ObjectFactory;
 import org.sdo.iotplatformsdk.common.protocol.types.OwnershipProxy;
 import org.slf4j.Logger;

--- a/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0SchedulerEvents.java
+++ b/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0SchedulerEvents.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0library;
 
 import java.time.Duration;
-
 import org.sdo.iotplatformsdk.common.protocol.types.OwnershipProxy;
 import org.sdo.iotplatformsdk.common.protocol.types.SdoError;
 

--- a/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To1dOwnerRedirect.java
+++ b/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To1dOwnerRedirect.java
@@ -1,16 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0library;
 
@@ -22,7 +11,6 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.URI;
 import java.util.Properties;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/to0scheduler/libto0/src/test/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0ScheduledClientSessionTest.java
+++ b/to0scheduler/libto0/src/test/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0ScheduledClientSessionTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0library;
 
@@ -21,7 +8,6 @@ import java.nio.CharBuffer;
 import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/config/To0ServiceApplication.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/config/To0ServiceApplication.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.config;
 
 import java.util.Collections;
-
 import org.springframework.boot.Banner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/config/To0ServiceConfiguration.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/config/To0ServiceConfiguration.java
@@ -1,22 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-
 import java.net.http.HttpClient;
 import java.nio.file.Paths;
 import java.security.SecureRandom;
@@ -24,9 +12,7 @@ import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-
 import javax.net.ssl.SSLContext;
-
 import org.sdo.iotplatformsdk.common.protocol.config.ObjectFactory;
 import org.sdo.iotplatformsdk.common.protocol.config.SecureRandomFactory;
 import org.sdo.iotplatformsdk.common.protocol.config.SslContextFactory;

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/RestClient.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/RestClient.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -27,9 +13,7 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
 import java.util.UUID;
-
 import javax.net.ssl.SSLContext;
-
 import org.sdo.iotplatformsdk.common.rest.DeviceState;
 import org.sdo.iotplatformsdk.common.rest.SignatureResponse;
 import org.sdo.iotplatformsdk.to0scheduler.to0service.To0PropertiesLoader;

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0Controller.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0Controller.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.rest;
 
 import java.time.Duration;
 import java.util.Arrays;
-
 import org.sdo.iotplatformsdk.common.rest.To0Request;
 import org.sdo.iotplatformsdk.to0scheduler.to0library.To0Scheduler;
 import org.slf4j.Logger;
@@ -30,7 +16,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import reactor.core.publisher.Mono;
 
 /**

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0ControllerAdvice.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0ControllerAdvice.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.rest;
 

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0CustomSslContextFactory.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0CustomSslContextFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.rest;
 
@@ -20,13 +7,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.security.SecureRandom;
-
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
-
 import org.sdo.iotplatformsdk.common.protocol.config.SslContextFactory;
 import org.sdo.iotplatformsdk.to0scheduler.to0service.To0PropertiesLoader;
 import org.slf4j.Logger;

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0HealthController.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0HealthController.java
@@ -1,21 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.rest;
 
 import java.sql.Timestamp;
-
 import org.sdo.iotplatformsdk.to0scheduler.to0service.To0PropertiesLoader;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0NoopSslContextFactory.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/To0NoopSslContextFactory.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.rest;
 
@@ -21,12 +8,10 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
-
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedTrustManager;
-
 import org.sdo.iotplatformsdk.common.protocol.config.SslContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0PropertiesLoader.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0PropertiesLoader.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0service;
 
@@ -20,7 +7,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0ProxystoreImpl.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0ProxystoreImpl.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0service;
 
 import java.io.IOException;
 import java.nio.CharBuffer;
-
 import org.sdo.iotplatformsdk.common.protocol.codecs.OwnershipProxyCodec;
 import org.sdo.iotplatformsdk.common.protocol.types.OwnershipProxy;
 import org.sdo.iotplatformsdk.to0scheduler.rest.RestClient;

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0SchedulerEventsImpl.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0SchedulerEventsImpl.java
@@ -1,24 +1,10 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0service;
 
 import java.time.Duration;
 import java.util.Optional;
-
 import org.sdo.iotplatformsdk.common.protocol.types.OwnershipProxy;
 import org.sdo.iotplatformsdk.common.protocol.types.SdoError;
 import org.sdo.iotplatformsdk.common.rest.DeviceState;

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0SignatureServiceFactoryImpl.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0SignatureServiceFactoryImpl.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0service;
 
@@ -25,7 +12,6 @@ import java.util.Base64;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
-
 import org.sdo.iotplatformsdk.common.protocol.security.SignatureService;
 import org.sdo.iotplatformsdk.common.protocol.security.SignatureServiceFactory;
 import org.sdo.iotplatformsdk.common.protocol.types.SignatureBlock;

--- a/to0scheduler/to0serviceimpl/src/test/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0ControllerAdviceTest.java
+++ b/to0scheduler/to0serviceimpl/src/test/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0ControllerAdviceTest.java
@@ -1,23 +1,9 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0service;
 
 import java.io.IOException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sdo.iotplatformsdk.to0scheduler.rest.To0ControllerAdvice;

--- a/to0scheduler/to0serviceimpl/src/test/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0ProxyStoreImplTest.java
+++ b/to0scheduler/to0serviceimpl/src/test/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0ProxyStoreImplTest.java
@@ -1,27 +1,12 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0service;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.UUID;
-
 import junit.framework.TestCase;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/to0scheduler/to0serviceimpl/src/test/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0SchedulerEventsImplTest.java
+++ b/to0scheduler/to0serviceimpl/src/test/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0SchedulerEventsImplTest.java
@@ -1,27 +1,12 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0service;
 
 import java.io.IOException;
 import java.nio.CharBuffer;
 import java.time.Duration;
-
 import junit.framework.TestCase;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/to0scheduler/to0serviceimpl/src/test/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0SignatureServiceFactoryImplTest.java
+++ b/to0scheduler/to0serviceimpl/src/test/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0SignatureServiceFactoryImplTest.java
@@ -1,18 +1,5 @@
-/*******************************************************************************
- * Copyright 2020 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *******************************************************************************/
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
 
 package org.sdo.iotplatformsdk.to0scheduler.to0service;
 
@@ -22,9 +9,7 @@ import java.nio.CharBuffer;
 import java.util.Base64;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-
 import junit.framework.TestCase;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
The copyright header were updated to use SPDX format, as checkstyle was
evaluating the other format as Javadoc.

Also the line separation rule for improt statements has been updated,
requiring deletion of empty lines between import groups.

A few other fixes correspond to multi-line comment format and spaces.

The commit doesn't introduce any functional change to the code.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>