### PR TITLE
Fixing memory leaks from HttpClient

### DIFF
--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     mem_limit: 500m
     mem_reservation: 200m
     cpu_shares: 5
-    pids_limit: 100
+    pids_limit: 300
     network_mode: host
     
   ocs:
@@ -54,7 +54,7 @@ services:
     mem_limit: 500m
     mem_reservation: 200m
     cpu_shares: 5
-    pids_limit: 100
+    pids_limit: 300
     network_mode: host
 
   ops:
@@ -77,5 +77,5 @@ services:
     mem_limit: 500m
     mem_reservation: 200m
     cpu_shares: 5
-    pids_limit: 100
+    pids_limit: 300
     network_mode: host

--- a/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0ClientSession.java
+++ b/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0ClientSession.java
@@ -16,6 +16,9 @@ import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.CharBuffer;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.net.ssl.SSLContext;
 import org.sdo.iotplatformsdk.common.protocol.codecs.PublicKeyCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.SignatureBlockCodec;
 import org.sdo.iotplatformsdk.common.protocol.codecs.To0AcceptOwnerCodec;
@@ -45,17 +48,17 @@ public class To0ClientSession {
   private static final Logger LOG = LoggerFactory.getLogger(To0ClientSession.class);
   private final SignatureServiceFactory signatureServiceFactory;
   private final URI to1dOwnerRedirectPath;
-  private final HttpClient httpClient;
+  private final SSLContext sslContext;
   private Duration to0WaitSeconds;
 
   /**
    * Constructor.
    */
   public To0ClientSession(final SignatureServiceFactory signatureServiceFactory,
-      URI to1dRedirectPath, HttpClient httpClient) {
+      URI to1dRedirectPath, SSLContext sslContext) {
     this.signatureServiceFactory = signatureServiceFactory;
     this.to1dOwnerRedirectPath = to1dRedirectPath;
-    this.httpClient = httpClient;
+    this.sslContext = sslContext;
   }
 
   public void setTo0WaitSeconds(Duration to0WaitSeconds) {
@@ -71,97 +74,112 @@ public class To0ClientSession {
    */
   public Duration run(OwnershipProxy proxy, URI uri)
       throws IOException, ExecutionException, InterruptedException {
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext)
+        .connectTimeout(Duration.ofSeconds(5)).executor(executor).build();
+    try {
+      // Which crypto level is used in this ownership voucher?
+      // Our registration should use the same level.
+      final CryptoLevel cryptoLevel = CryptoLevels.find(proxy.getHmac().getType())
+          .orElseThrow(() -> new IllegalArgumentException("no crypto level for proxy"));
 
-    // Which crypto level is used in this ownership voucher?
-    // Our registration should use the same level.
-    final CryptoLevel cryptoLevel = CryptoLevels.find(proxy.getHmac().getType())
-        .orElseThrow(() -> new IllegalArgumentException("no crypto level for proxy"));
+      final To0Hello hello = new To0Hello();
+      StringWriter writer = new StringWriter();
 
-    final To0Hello hello = new To0Hello();
-    StringWriter writer = new StringWriter();
+      // Sends TO0Hello - message 20 compose
+      new To0HelloCodec().encoder().apply(writer, hello);
+      String request = writer.toString();
 
-    // Sends TO0Hello - message 20 compose
-    new To0HelloCodec().encoder().apply(writer, hello);
-    String request = writer.toString();
+      // Sends TO0Hello - message 20 to the server.
+      final HttpRequest.Builder httpRequestBuilder =
+          HttpRequest.newBuilder().header("Content-Type", "application/json");
+      HttpRequest httpRequest =
+          httpRequestBuilder.uri(uri.resolve(SdoUriComponentsBuilder.path(To0Hello.ID)))
+              .POST(BodyPublishers.ofString(request)).build();
+      LOG.info("[HTTP Request]: " + httpRequest.method() + " " + httpRequest.uri());
 
-    // Sends TO0Hello - message 20 to the server.
-    final HttpRequest.Builder httpRequestBuilder =
-        HttpRequest.newBuilder().header("Content-Type", "application/json");
-    HttpRequest httpRequest =
-        httpRequestBuilder.uri(uri.resolve(SdoUriComponentsBuilder.path(To0Hello.ID)))
-            .POST(BodyPublishers.ofString(request)).build();
-    LOG.info("[HTTP Request]: " + httpRequest.method() + " " + httpRequest.uri());
+      HttpResponse<String> httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
+      if (httpResponse.statusCode() != 200) {
+        throw new IOException(httpResponse.toString() + " " + httpResponse.body());
+      }
 
-    HttpResponse<String> httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-    if (httpResponse.statusCode() != 200) {
-      throw new IOException(httpResponse.toString() + " " + httpResponse.body());
+      String response = null != httpResponse.body() ? httpResponse.body() : "";
+      LOG.info("[HTTP Response]: " + httpResponse.toString());
+
+      final String authToken = httpResponse.headers().firstValue("Authorization").get();
+
+      // Decoding the response from the server Receiving message 21 from the server.
+      final To0HelloAck helloAck =
+          new To0HelloAckCodec().decoder().apply(CharBuffer.wrap(response));
+
+      // Composing To0d of message 22 To compose the message, retrieving the nonce (n3) from the
+      // server response.
+      final To0OwnerSignTo0d to0d = new To0OwnerSignTo0d(proxy, to0WaitSeconds, helloAck.getN3());
+
+      writer = new StringWriter();
+
+      // Encoding To0d (in message 22 format, to0d is encoded)
+      new To0dEncoder().encode(writer, to0d);
+
+      // Calculating the hash of to0d which is a part of to1d.
+      final HashDigest to0dh =
+          cryptoLevel.getDigestService().digestOf(US_ASCII.encode(writer.toString()));
+
+      // Composing to1d.
+      final To1dOwnerRedirect to1dOwnerRedirect = new To1dOwnerRedirect(to1dOwnerRedirectPath);
+      final To1SdoRedirect redirect = new To1SdoRedirect(to1dOwnerRedirect.getI1(),
+          to1dOwnerRedirect.getDns1(), to1dOwnerRedirect.getPort1(), to0dh);
+
+      writer = new StringWriter();
+      new To1SdoRedirectCodec().encoder().apply(writer, redirect);
+      final SignatureBlock sig =
+          signatureServiceFactory.build(proxy.getOh().getG()).sign(writer.toString()).get();
+      // to1d.pk must be null, per protocol spec
+      final SignatureBlock to1d = new SignatureBlock(sig.getBo(), null, sig.getSg());
+
+      // Composing message 22 and encoding it.
+      final To0OwnerSign ownerSign = new To0OwnerSign(to0d, to1d);
+      writer = new StringWriter();
+      new To0OwnerSignCodec.To0OwnerSignEncoder(
+          new SignatureBlockCodec.Encoder(new PublicKeyCodec.Encoder(proxy.getOh().getPe())))
+              .encode(writer, ownerSign);
+      request = writer.toString();
+
+      // Sending request to RZ server
+      httpRequest = httpRequestBuilder.header("Authorization", authToken)
+          .uri(uri.resolve(SdoUriComponentsBuilder.path(To0OwnerSign.ID)))
+          .POST(BodyPublishers.ofString(request)).build();
+      LOG.info(
+          "[HTTP Request]: " + httpRequest.method() + " " + httpRequest.uri() + "\n" + request);
+
+      // Receiving message 23 from server
+      httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
+      if (httpResponse.statusCode() != 200) {
+        throw new IOException(httpResponse.toString() + " " + httpResponse.body());
+      }
+      response = null != httpResponse.body() ? httpResponse.body() : "";
+      LOG.info("[HTTP Response]: " + httpResponse.toString());
+
+      // Decoding message 23 The New Owner Client can drop the connection after this message is
+      // processed. If the new Owner does not receive a Transfer Ownership connection from a Device
+      // within waitSeconds seconds, it must repeat Transfer Ownership Protocol 0 and re-register
+      // its
+      // GUID to address association.
+      final To0AcceptOwner acceptOwner =
+          new To0AcceptOwnerCodec().decoder().apply(CharBuffer.wrap(response));
+
+      // If the new Owner does not receive a Transfer Ownership connection from a Device within
+      // waitSeconds seconds, it must repeat Transfer Ownership Protocol 0 and re-register its GUID
+      // to
+      // address association.
+      return acceptOwner.getWs();
+
+    } catch (Exception e) {
+      throw e;
+    } finally {
+      // avoiding memory leaks.
+      executor.shutdownNow();
+      httpClient = null;
     }
-
-    String response = null != httpResponse.body() ? httpResponse.body() : "";
-    LOG.info("[HTTP Response]: " + httpResponse.toString());
-
-    final String authToken = httpResponse.headers().firstValue("Authorization").get();
-
-    // Decoding the response from the server Receiving message 21 from the server.
-    final To0HelloAck helloAck = new To0HelloAckCodec().decoder().apply(CharBuffer.wrap(response));
-
-    // Composing To0d of message 22 To compose the message, retrieving the nonce (n3) from the
-    // server response.
-    final To0OwnerSignTo0d to0d = new To0OwnerSignTo0d(proxy, to0WaitSeconds, helloAck.getN3());
-
-    writer = new StringWriter();
-
-    // Encoding To0d (in message 22 format, to0d is encoded)
-    new To0dEncoder().encode(writer, to0d);
-
-    // Calculating the hash of to0d which is a part of to1d.
-    final HashDigest to0dh =
-        cryptoLevel.getDigestService().digestOf(US_ASCII.encode(writer.toString()));
-
-    // Composing to1d.
-    final To1dOwnerRedirect to1dOwnerRedirect = new To1dOwnerRedirect(to1dOwnerRedirectPath);
-    final To1SdoRedirect redirect = new To1SdoRedirect(to1dOwnerRedirect.getI1(),
-        to1dOwnerRedirect.getDns1(), to1dOwnerRedirect.getPort1(), to0dh);
-
-    writer = new StringWriter();
-    new To1SdoRedirectCodec().encoder().apply(writer, redirect);
-    final SignatureBlock sig =
-        signatureServiceFactory.build(proxy.getOh().getG()).sign(writer.toString()).get();
-    // to1d.pk must be null, per protocol spec
-    final SignatureBlock to1d = new SignatureBlock(sig.getBo(), null, sig.getSg());
-
-    // Composing message 22 and encoding it.
-    final To0OwnerSign ownerSign = new To0OwnerSign(to0d, to1d);
-    writer = new StringWriter();
-    new To0OwnerSignCodec.To0OwnerSignEncoder(
-        new SignatureBlockCodec.Encoder(new PublicKeyCodec.Encoder(proxy.getOh().getPe())))
-            .encode(writer, ownerSign);
-    request = writer.toString();
-
-    // Sending request to RZ server
-    httpRequest = httpRequestBuilder.header("Authorization", authToken)
-        .uri(uri.resolve(SdoUriComponentsBuilder.path(To0OwnerSign.ID)))
-        .POST(BodyPublishers.ofString(request)).build();
-    LOG.info("[HTTP Request]: " + httpRequest.method() + " " + httpRequest.uri() + "\n" + request);
-
-    // Receiving message 23 from server
-    httpResponse = httpClient.send(httpRequest, BodyHandlers.ofString());
-    if (httpResponse.statusCode() != 200) {
-      throw new IOException(httpResponse.toString() + " " + httpResponse.body());
-    }
-    response = null != httpResponse.body() ? httpResponse.body() : "";
-    LOG.info("[HTTP Response]: " + httpResponse.toString());
-
-    // Decoding message 23 The New Owner Client can drop the connection after this message is
-    // processed. If the new Owner does not receive a Transfer Ownership connection from a Device
-    // within waitSeconds seconds, it must repeat Transfer Ownership Protocol 0 and re-register its
-    // GUID to address association.
-    final To0AcceptOwner acceptOwner =
-        new To0AcceptOwnerCodec().decoder().apply(CharBuffer.wrap(response));
-
-    // If the new Owner does not receive a Transfer Ownership connection from a Device within
-    // waitSeconds seconds, it must repeat Transfer Ownership Protocol 0 and re-register its GUID to
-    // address association.
-    return acceptOwner.getWs();
   }
 }

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/config/To0ServiceConfiguration.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/config/To0ServiceConfiguration.java
@@ -5,7 +5,6 @@ package org.sdo.iotplatformsdk.to0scheduler.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import java.net.http.HttpClient;
 import java.nio.file.Paths;
 import java.security.SecureRandom;
 import java.time.Duration;
@@ -119,8 +118,7 @@ public class To0ServiceConfiguration {
           sslContext = sslContextFactory().getObject();
         }
         return new To0ClientSession(signatureServiceFactory(),
-            Paths.get(".").toUri().resolve(redirectInfo).normalize(), HttpClient.newBuilder()
-                .sslContext(sslContext).connectTimeout(httpClientTimeout).build());
+            Paths.get(".").toUri().resolve(redirectInfo).normalize(), sslContext);
       }
     };
   }

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/RestClient.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/RestClient.java
@@ -13,6 +13,8 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import javax.net.ssl.SSLContext;
 import org.sdo.iotplatformsdk.common.rest.DeviceState;
 import org.sdo.iotplatformsdk.common.rest.SignatureResponse;
@@ -55,14 +57,15 @@ public class RestClient {
    * @return the owner voucher.
    */
   public String getDeviceVoucher(final String deviceId) {
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
+        .connectTimeout(httpClientTimeout).executor(executor).build();
     try {
       final String apiServer = To0PropertiesLoader.getProperty("rest.api.server");
       final String path = To0PropertiesLoader.getProperty("rest.api.voucher.path");
       final String revisedPath = path.replace("{deviceId}", deviceId);
       final URI uri = URI.create(apiServer + revisedPath);
 
-      final HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
-          .connectTimeout(httpClientTimeout).build();
       final HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
           .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
           .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
@@ -79,8 +82,11 @@ public class RestClient {
           "Error occurred while fetching the voucher for " + deviceId + ". " + e.getMessage());
       logger.debug(e.getMessage(), e);
       return null;
+    } finally {
+      // avoiding memory leaks.
+      executor.shutdownNow();
+      httpClient = null;
     }
-
   }
 
   /**
@@ -91,6 +97,9 @@ public class RestClient {
    * @param state    device state object.
    */
   public void postDeviceState(final String deviceId, final DeviceState state) {
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
+        .connectTimeout(httpClientTimeout).executor(executor).build();
     try {
       final String apiServer = To0PropertiesLoader.getProperty("rest.api.server");
       final String path = To0PropertiesLoader.getProperty("rest.api.device.state.path");
@@ -98,8 +107,6 @@ public class RestClient {
       final URI uri = URI.create(apiServer + revisedPath);
 
       final String requestBody = objectMapper().writeValueAsString(state);
-      final HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
-          .connectTimeout(httpClientTimeout).build();
       final HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
           .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
       final HttpRequest httpRequest =
@@ -113,6 +120,10 @@ public class RestClient {
       logger.error(
           "Error occurred while setting the devices state for " + deviceId + ". " + e.getMessage());
       logger.debug(e.getMessage(), e);
+    } finally {
+      // avoiding memory leaks.
+      executor.shutdownNow();
+      httpClient = null;
     }
   }
 
@@ -125,14 +136,15 @@ public class RestClient {
    * @return
    */
   public SignatureResponse signatureOperation(final UUID uuid, final String bo) {
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
+        .connectTimeout(httpClientTimeout).executor(executor).build();
     try {
       final String apiServer = To0PropertiesLoader.getProperty("rest.api.server");
       final String path = To0PropertiesLoader.getProperty("rest.api.signature.path");
       final String revisedPath = path.replace("{deviceId}", uuid.toString());
       final URI uri = URI.create(apiServer + revisedPath);
 
-      final HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
-          .connectTimeout(httpClientTimeout).build();
       final HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
           .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
           .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
@@ -152,6 +164,10 @@ public class RestClient {
           + e.getMessage());
       logger.debug(e.getMessage(), e);
       return null;
+    } finally {
+      // avoiding memory leaks.
+      executor.shutdownNow();
+      httpClient = null;
     }
   }
 
@@ -163,6 +179,9 @@ public class RestClient {
    * @param state    device state information containing the error.
    */
   public void postError(final String deviceId, final DeviceState state) {
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
+        .connectTimeout(httpClientTimeout).executor(executor).build();
     try {
       final String apiServer = To0PropertiesLoader.getProperty("rest.api.server");
       final String path = To0PropertiesLoader.getProperty("rest.api.error.path");
@@ -170,8 +189,6 @@ public class RestClient {
       final URI uri = URI.create(apiServer + revisedPath);
 
       final String requestBody = objectMapper().writeValueAsString(state);
-      final HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
-          .connectTimeout(httpClientTimeout).build();
       final HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
           .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
       final HttpRequest httpRequest =
@@ -185,6 +202,10 @@ public class RestClient {
       logger.error(
           "Error occurred while setting the devices state for " + deviceId + ". " + e.getMessage());
       logger.debug(e.getMessage(), e);
+    } finally {
+      // avoiding memory leaks.
+      executor.shutdownNow();
+      httpClient = null;
     }
   }
 }


### PR DESCRIPTION
Creating a local single-thread ExecutorService and assigning to the
HttpClient so that HttpClient doesn't create its own. Also, manually
shutting down the Executor and nulling HttpClient so that they are
available for garbage collection.
Additionally, updating the pids limit of the docker container from 100
to 300 to allow thread creation by increased number of devices.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>