### PR TITLE
Updates to blank property handling and fixing typo

### DIFF
--- a/demo/ocs/ocs.env
+++ b/demo/ocs/ocs.env
@@ -48,7 +48,7 @@ TO0_SCHEDULER_INTERVAL=60
 # The flag that enables or disables the SDO Credential-Reuse condition.
 # If true, OCS sends the same GUID and Rendezvous Instructions.
 # If false, OCS sends a new GUID and new/same Rendezvous information.
-TO0_CREDENTIAL_REUSE_ENABLED=false
+TO2_CREDENTIAL_REUSE_ENABLED=false
 
 # The flag that determines whether the Resale protocol is supported by the Owner.
 # If true, resale protocol is supported as per the specification.

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsPropertiesLoader.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/fs/FsPropertiesLoader.java
@@ -68,6 +68,7 @@ public class FsPropertiesLoader {
         propertiesMap.put(property, fileBasedConfiguration.getString(property));
       }
     }
-    return propertiesMap.get(property);
+    return (null == propertiesMap.get(property) || propertiesMap.get(property).isBlank()) ? null
+        : propertiesMap.get(property);
   }
 }

--- a/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsPropertiesLoader.java
+++ b/ops/restimpl/src/main/java/org/sdo/iotplatformsdk/ops/opsimpl/OpsPropertiesLoader.java
@@ -68,6 +68,7 @@ public class OpsPropertiesLoader {
         propertiesMap.put(property, fileBasedConfiguration.getString(property));
       }
     }
-    return propertiesMap.get(property);
+    return (null == propertiesMap.get(property) || propertiesMap.get(property).isBlank()) ? null
+        : propertiesMap.get(property);
   }
 }

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0PropertiesLoader.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0service/To0PropertiesLoader.java
@@ -68,6 +68,7 @@ public class To0PropertiesLoader {
         propertiesMap.put(property, fileBasedConfiguration.getString(property));
       }
     }
-    return propertiesMap.get(property);
+    return (null == propertiesMap.get(property) || propertiesMap.get(property).isBlank()) ? null
+        : propertiesMap.get(property);
   }
 }


### PR DESCRIPTION
- Updating property handler to return null, in case any of the
property's value is blank.
- Fixing a typo in property at ocs.env.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>