### PR TITLE
Set the sandbox EPID verifier as default for demo

### DIFF
--- a/demo/ocs/ocs.env
+++ b/demo/ocs/ocs.env
@@ -35,7 +35,7 @@ FS_VALUES_DIR=v1/values
 
 # REST endpoint that points to the API hosted by To0Scheduler: URL
 # Only domain and port are configurable.
-# For ex: https://10.66.247.90:8050/v1/to0/devices
+# For ex: https://192.168.1.1:8050/v1/to0/devices
 TO0_REST_API=https://localhost:8049/v1/to0/devices
 
 # The number of seconds until which TO0 is valid: Number

--- a/demo/ops/ops.env
+++ b/demo/ops/ops.env
@@ -21,7 +21,7 @@ THREAD_POOL_SIZE=10
 # If this property is set, the online verification of EPID keys is performed
 # by making a request to this URL.
 # For example, https://online-verification-service.com
-#ORG_SDO_EPID_EPID_ONLINE_URL=
+ORG_SDO_EPID_EPID_ONLINE_URL=https://verify.epid-sbx.trustedservices.intel.com/
 
 # Optional : Boolean
 # The test-mode parameter indicates whether we should be using EPID development


### PR DESCRIPTION
For demo operations, the sandbox EPID verifier service is used instead
of production EPID verifier service. Both the services use the same
backend logic.

While at it, updated the comment about example IP address.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>