### PR TITLE
Migrate to use Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ to retrieve customer-specific artifacts.
 # Getting started with the SDO IoT Platform SDK
 
 The following are the system constraints for the SDO IoT Platform SDK:
-- Operating System: Ubuntu* 18.04
+- Operating System: Ubuntu* 20.04
 - Java* Development Kit 11
 - Apache Maven* 3.5.4 (Optional) software for building the SDO IoT Platform SDK from source
 - Java IDE (Optional) for convenience in modifying the source code (especially for customizing OCS).

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-FROM ubuntu:bionic
+FROM ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install -y git  \

--- a/build/README.md
+++ b/build/README.md
@@ -4,7 +4,7 @@ Docker Script for Building IOT-platform-SDK repository. Using this script you ca
 
 ## Prerequisites
 
-- Operating system: **Ubuntu 18.04.**
+- Operating system: **Ubuntu 20.04.**
 
 - Docker engine : **18.06.0**
 

--- a/demo/ocs/Dockerfile
+++ b/demo/ocs/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG _JAVA_OPTIONS
 ENV _JAVA_OPTIONS=${_JAVA_OPTIONS}
 RUN apt-get update && apt-get install -y libssl-dev

--- a/demo/ops/Dockerfile
+++ b/demo/ops/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG _JAVA_OPTIONS
 ENV _JAVA_OPTIONS=${_JAVA_OPTIONS}
 RUN apt-get update && apt-get install -y libssl-dev

--- a/demo/to0scheduler/Dockerfile
+++ b/demo/to0scheduler/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG _JAVA_OPTIONS
 ENV _JAVA_OPTIONS=${_JAVA_OPTIONS}
 RUN apt-get update && apt-get install -y libssl-dev


### PR DESCRIPTION
Migrate build and runtime containers to use Ubuntu 20.04.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>