### PR TITLE
Adding default HTTP version to HTTPClient

### DIFF
--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/FsRestClient.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/FsRestClient.java
@@ -106,7 +106,7 @@ public class FsRestClient {
   public void postDevicesForTo0(final To0Request request) {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext()).connectTimeout(timeout)
-        .executor(executor).build();
+        .executor(executor).version(HttpClient.Version.HTTP_1_1).build();
     try {
       final String requestBody = new ObjectMapper().writeValueAsString(request);
       final HttpRequest.Builder httpRequestBuilder =

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidOnlineMaterial.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidOnlineMaterial.java
@@ -116,7 +116,7 @@ public class EpidOnlineMaterial {
     try {
       httpClient = HttpClient.newBuilder()
           .sslContext(new SslContextFactory(new SecureRandomFactory().getObject()).getObject())
-          .build();
+          .version(HttpClient.Version.HTTP_1_1).build();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidOnlineVerifier.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidOnlineVerifier.java
@@ -66,7 +66,7 @@ public class EpidOnlineVerifier {
     try {
       httpClient = HttpClient.newBuilder()
           .sslContext(new SslContextFactory(new SecureRandomFactory().getObject()).getObject())
-          .build();
+          .version(HttpClient.Version.HTTP_1_1).build();
     } catch (Exception e) {
       return EpidLib.EpidStatus.kEpidErr.getValue();
     }

--- a/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0ClientSession.java
+++ b/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0ClientSession.java
@@ -76,7 +76,8 @@ public class To0ClientSession {
       throws IOException, ExecutionException, InterruptedException {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext)
-        .connectTimeout(Duration.ofSeconds(5)).executor(executor).build();
+        .connectTimeout(Duration.ofSeconds(5)).executor(executor)
+        .version(HttpClient.Version.HTTP_1_1).build();
     try {
       // Which crypto level is used in this ownership voucher?
       // Our registration should use the same level.

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/RestClient.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/RestClient.java
@@ -59,7 +59,8 @@ public class RestClient {
   public String getDeviceVoucher(final String deviceId) {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
-        .connectTimeout(httpClientTimeout).executor(executor).build();
+        .connectTimeout(httpClientTimeout).executor(executor)
+        .version(HttpClient.Version.HTTP_1_1).build();
     try {
       final String apiServer = To0PropertiesLoader.getProperty("rest.api.server");
       final String path = To0PropertiesLoader.getProperty("rest.api.voucher.path");
@@ -99,7 +100,8 @@ public class RestClient {
   public void postDeviceState(final String deviceId, final DeviceState state) {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
-        .connectTimeout(httpClientTimeout).executor(executor).build();
+        .connectTimeout(httpClientTimeout).executor(executor)
+        .version(HttpClient.Version.HTTP_1_1).build();
     try {
       final String apiServer = To0PropertiesLoader.getProperty("rest.api.server");
       final String path = To0PropertiesLoader.getProperty("rest.api.device.state.path");
@@ -138,7 +140,8 @@ public class RestClient {
   public SignatureResponse signatureOperation(final UUID uuid, final String bo) {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
-        .connectTimeout(httpClientTimeout).executor(executor).build();
+        .connectTimeout(httpClientTimeout).executor(executor)
+        .version(HttpClient.Version.HTTP_1_1).build();
     try {
       final String apiServer = To0PropertiesLoader.getProperty("rest.api.server");
       final String path = To0PropertiesLoader.getProperty("rest.api.signature.path");
@@ -181,7 +184,8 @@ public class RestClient {
   public void postError(final String deviceId, final DeviceState state) {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
-        .connectTimeout(httpClientTimeout).executor(executor).build();
+        .connectTimeout(httpClientTimeout).executor(executor)
+        .version(HttpClient.Version.HTTP_1_1).build();
     try {
       final String apiServer = To0PropertiesLoader.getProperty("rest.api.server");
       final String path = To0PropertiesLoader.getProperty("rest.api.error.path");


### PR DESCRIPTION
Porting fix from PRI for an issue where HTTPClient is unable to connect to URLs without proxies, by adding the HTTP version to the HTTPClient instance.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>