### PR TITLE
Adding default HTTP version to HTTPClient

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>iotplatformsdk</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/common/protocol/pom.xml
+++ b/common/protocol/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.sdo.iotplatformsdk</groupId>
     <artifactId>common</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/common/rest/pom.xml
+++ b/common/rest/pom.xml
@@ -18,8 +18,8 @@
 
   <parent>
     <groupId>org.sdo.iotplatformsdk</groupId>
-	<artifactId>common</artifactId>
-    <version>1.9</version>
+    <artifactId>common</artifactId>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ocs/fsimpl/pom.xml
+++ b/ocs/fsimpl/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.sdo.iotplatformsdk</groupId>
     <artifactId>ocs</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
   </parent>
 
   <dependencies>

--- a/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/FsRestClient.java
+++ b/ocs/fsimpl/src/main/java/org/sdo/iotplatformsdk/ocs/fsimpl/rest/FsRestClient.java
@@ -106,7 +106,7 @@ public class FsRestClient {
   public void postDevicesForTo0(final To0Request request) {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext()).connectTimeout(timeout)
-        .executor(executor).build();
+        .executor(executor).version(HttpClient.Version.HTTP_1_1).build();
     try {
       final String requestBody = new ObjectMapper().writeValueAsString(request);
       final HttpRequest.Builder httpRequestBuilder =

--- a/ocs/libocs/pom.xml
+++ b/ocs/libocs/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.sdo.iotplatformsdk</groupId>
     <artifactId>ocs</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ocs/pom.xml
+++ b/ocs/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>iotplatformsdk</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ops/epid/pom.xml
+++ b/ops/epid/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.sdo.iotplatformsdk</groupId>
     <artifactId>ops</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidOnlineMaterial.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidOnlineMaterial.java
@@ -116,7 +116,7 @@ public class EpidOnlineMaterial {
     try {
       httpClient = HttpClient.newBuilder()
           .sslContext(new SslContextFactory(new SecureRandomFactory().getObject()).getObject())
-          .build();
+          .version(HttpClient.Version.HTTP_1_1).build();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidOnlineVerifier.java
+++ b/ops/epid/src/main/java/org/sdo/iotplatformsdk/ops/epid/EpidOnlineVerifier.java
@@ -66,7 +66,7 @@ public class EpidOnlineVerifier {
     try {
       httpClient = HttpClient.newBuilder()
           .sslContext(new SslContextFactory(new SecureRandomFactory().getObject()).getObject())
-          .build();
+          .version(HttpClient.Version.HTTP_1_1).build();
     } catch (Exception e) {
       return EpidLib.EpidStatus.kEpidErr.getValue();
     }

--- a/ops/libops/pom.xml
+++ b/ops/libops/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.sdo.iotplatformsdk</groupId>
     <artifactId>ops</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
   </parent>
 
   <dependencies>

--- a/ops/pom.xml
+++ b/ops/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>iotplatformsdk</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/ops/restimpl/pom.xml
+++ b/ops/restimpl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.sdo.iotplatformsdk</groupId>
     <artifactId>ops</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
   </parent>
 
   <dependencies>

--- a/ops/serviceinfo/pom.xml
+++ b/ops/serviceinfo/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.sdo.iotplatformsdk</groupId>
     <artifactId>ops</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
   </parent>
 
   <properties>
+    <tomcat.version>9.0.40</tomcat.version>
     <com.fasterxml.jackson.version>2.10.5</com.fasterxml.jackson.version>
     <com.fasterxml.jackson.databind.version>2.10.5.1</com.fasterxml.jackson.databind.version>
     <org.bouncycastle.version>1.66</org.bouncycastle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <description>SDO IoT Platform SDK</description>
   <groupId>org.sdo</groupId>
   <artifactId>iotplatformsdk</artifactId>
-  <version>1.9</version>
+  <version>1.9.1</version>
   <name>SDO IoT Platform SDK</name>
   <packaging>pom</packaging>
   <url>file:///tmp/sdo</url>
@@ -19,15 +19,16 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.2.RELEASE</version>
+    <version>2.3.5.RELEASE</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
   <properties>
-    <com.fasterxml.jackson.version>2.10.3</com.fasterxml.jackson.version>
+    <com.fasterxml.jackson.version>2.10.5</com.fasterxml.jackson.version>
+    <com.fasterxml.jackson.databind.version>2.10.5.1</com.fasterxml.jackson.databind.version>
     <org.bouncycastle.version>1.66</org.bouncycastle.version>
     <org.jsoup.jsoup.version>1.13.1</org.jsoup.jsoup.version>
-    <org.apache.httpcomponents.version>4.5.12</org.apache.httpcomponents.version>
+    <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>
     <org.apache.commons.configuration2.version>2.7</org.apache.commons.configuration2.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <io.projectreactor.version>3.3.9.RELEASE</io.projectreactor.version>
@@ -167,7 +168,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${com.fasterxml.jackson.version}</version>
+        <version>${com.fasterxml.jackson.databind.version}</version>
       </dependency>
 
       <dependency>

--- a/to0scheduler/libto0/pom.xml
+++ b/to0scheduler/libto0/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.sdo.iotplatformsdk</groupId>
     <artifactId>to0service</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
   </parent>
 
   <dependencies>

--- a/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0ClientSession.java
+++ b/to0scheduler/libto0/src/main/java/org/sdo/iotplatformsdk/to0scheduler/to0library/To0ClientSession.java
@@ -76,7 +76,8 @@ public class To0ClientSession {
       throws IOException, ExecutionException, InterruptedException {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext)
-        .connectTimeout(Duration.ofSeconds(5)).executor(executor).build();
+        .connectTimeout(Duration.ofSeconds(5)).executor(executor)
+        .version(HttpClient.Version.HTTP_1_1).build();
     try {
       // Which crypto level is used in this ownership voucher?
       // Our registration should use the same level.

--- a/to0scheduler/pom.xml
+++ b/to0scheduler/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>iotplatformsdk</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/to0scheduler/to0serviceimpl/pom.xml
+++ b/to0scheduler/to0serviceimpl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.sdo.iotplatformsdk</groupId>
     <artifactId>to0service</artifactId>
-    <version>1.9</version>
+    <version>1.9.1</version>
   </parent>
 
   <dependencies>

--- a/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/RestClient.java
+++ b/to0scheduler/to0serviceimpl/src/main/java/org/sdo/iotplatformsdk/to0scheduler/rest/RestClient.java
@@ -59,7 +59,8 @@ public class RestClient {
   public String getDeviceVoucher(final String deviceId) {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
-        .connectTimeout(httpClientTimeout).executor(executor).build();
+        .connectTimeout(httpClientTimeout).executor(executor)
+        .version(HttpClient.Version.HTTP_1_1).build();
     try {
       final String apiServer = To0PropertiesLoader.getProperty("rest.api.server");
       final String path = To0PropertiesLoader.getProperty("rest.api.voucher.path");
@@ -99,7 +100,8 @@ public class RestClient {
   public void postDeviceState(final String deviceId, final DeviceState state) {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
-        .connectTimeout(httpClientTimeout).executor(executor).build();
+        .connectTimeout(httpClientTimeout).executor(executor)
+        .version(HttpClient.Version.HTTP_1_1).build();
     try {
       final String apiServer = To0PropertiesLoader.getProperty("rest.api.server");
       final String path = To0PropertiesLoader.getProperty("rest.api.device.state.path");
@@ -138,7 +140,8 @@ public class RestClient {
   public SignatureResponse signatureOperation(final UUID uuid, final String bo) {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
-        .connectTimeout(httpClientTimeout).executor(executor).build();
+        .connectTimeout(httpClientTimeout).executor(executor)
+        .version(HttpClient.Version.HTTP_1_1).build();
     try {
       final String apiServer = To0PropertiesLoader.getProperty("rest.api.server");
       final String path = To0PropertiesLoader.getProperty("rest.api.signature.path");
@@ -181,7 +184,8 @@ public class RestClient {
   public void postError(final String deviceId, final DeviceState state) {
     final ExecutorService executor = Executors.newSingleThreadExecutor();
     HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext())
-        .connectTimeout(httpClientTimeout).executor(executor).build();
+        .connectTimeout(httpClientTimeout).executor(executor)
+        .version(HttpClient.Version.HTTP_1_1).build();
     try {
       final String apiServer = To0PropertiesLoader.getProperty("rest.api.server");
       final String path = To0PropertiesLoader.getProperty("rest.api.error.path");


### PR DESCRIPTION
When IOT Platform SDK is executed in an open network, the HTTP Clients
are not able to connect to hosted Rendezvous Service.

The issue is resolved by setting the HTTP version to 1.1 explicitly
while creating the required HTTP clients.

While at it, update the third-party package vesions to fix known
security vulnerabilities.

Signed-off-by: Chandrakar, Prateek <prateek.chandrakar@intel.com>
Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>