### PR TITLE
Updating Dependency Libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,13 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.5.RELEASE</version>
+    <version>2.3.8.RELEASE</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
   <properties>
-    <com.fasterxml.jackson.version>2.10.3</com.fasterxml.jackson.version>
-    <org.bouncycastle.version>1.66</org.bouncycastle.version>
+    <com.fasterxml.jackson.version>2.12.1</com.fasterxml.jackson.version>
+    <org.bouncycastle.version>1.68</org.bouncycastle.version>
     <org.jsoup.jsoup.version>1.13.1</org.jsoup.jsoup.version>
     <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>
     <org.apache.commons.configuration2.version>2.7</org.apache.commons.configuration2.version>


### PR DESCRIPTION
  Updating Dependency Libraries to patch security vulnerability.

  Includes update to:

  Bouncycastle 1.66 --> 1.68
  Spring-boot-starter 2.3.5.RELEASE --> 2.3.8.RELEASE

Signed-off-by: Davis Benny <davis.benny@intel.com>