### PR TITLE
Updating fasterxml.jackson version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <tomcat.version>9.0.43</tomcat.version>
-    <com.fasterxml.jackson.version>2.12.1</com.fasterxml.jackson.version>
+    <com.fasterxml.jackson.version>2.11.4</com.fasterxml.jackson.version>
     <org.bouncycastle.version>1.68</org.bouncycastle.version>
     <org.jsoup.jsoup.version>1.13.1</org.jsoup.jsoup.version>
     <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>


### PR DESCRIPTION
   Downgrading fasterxml.jackson version to 2.11.4 as
   2.12.2 is having compatibilty issues with t0scheduler.

Signed-off-by: Davis Benny <davis.benny@intel.com>