### PR TITLE
Update third-party package versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,23 +19,23 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.8.RELEASE</version>
+    <version>2.3.11.RELEASE</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
   <properties>
-    <tomcat.version>9.0.43</tomcat.version>
-    <com.fasterxml.jackson.version>2.11.4</com.fasterxml.jackson.version>
+    <tomcat.version>9.0.46</tomcat.version>
+    <com.fasterxml.jackson.version>2.12.3</com.fasterxml.jackson.version>
     <org.bouncycastle.version>1.68</org.bouncycastle.version>
     <org.jsoup.jsoup.version>1.13.1</org.jsoup.jsoup.version>
     <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>
     <org.apache.commons.configuration2.version>2.7</org.apache.commons.configuration2.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
-    <io.projectreactor.version>3.3.9.RELEASE</io.projectreactor.version>
+    <io.projectreactor.version>3.4.6</io.projectreactor.version>
     <javax.xml.bind.version>2.3.1</javax.xml.bind.version>
     <org.slf4j.version>1.7.30</org.slf4j.version>
     <org.mockito.version>1.10.19</org.mockito.version>
-    <junit-jupiter.version>5.6.3</junit-jupiter.version>
+    <junit-jupiter.version>5.7.2</junit-jupiter.version>
     <org.apache.maven.plugins.maven-checkstyle-plugin.version>
       3.1.0
     </org.apache.maven.plugins.maven-checkstyle-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <tomcat.version>9.0.46</tomcat.version>
-    <com.fasterxml.jackson.version>2.12.3</com.fasterxml.jackson.version>
+    <com.fasterxml.jackson.version>2.11.4</com.fasterxml.jackson.version>
     <org.bouncycastle.version>1.68</org.bouncycastle.version>
     <org.jsoup.jsoup.version>1.13.1</org.jsoup.jsoup.version>
     <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>


### PR DESCRIPTION
Version for following third-party packages were updated.

jackson-core (2.11.4 -> 2.12.3)
jackson-databind (2.11.4 -> 2.12.3)
junit-jupiter (5.6.2 -> 5.7.2)
reactor-core (3.3.9.RELEASE -> 3.4.6)
spring-boot (2.3.8.RELEASE -> 2.3.11.RELEASE)
tomcat (9.0.43 -> 9.0.46)

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>