### PR TITLE
Upgrading Log4j version to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <org.apache.maven.plugins.maven-checkstyle-plugin.version>
       3.1.0
     </org.apache.maven.plugins.maven-checkstyle-plugin.version>
+    <log4j.version>2.15.0</log4j.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
  Upgrading Log4j version to 2.15.0 from 2.14.1

  CVE-2021-44228 was issued for Log4j 2.14.1 component.

Signed-off-by: Davis Benny <davis.benny@intel.com>