### PR TITLE
Upgrading dependencies to the latest version

### DIFF
--- a/ocs/fsimpl/pom.xml
+++ b/ocs/fsimpl/pom.xml
@@ -32,10 +32,32 @@
       <artifactId>spring-boot-starter-web</artifactId>
       <exclusions>
         <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-json</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
 
     <dependency>

--- a/ops/restimpl/pom.xml
+++ b/ops/restimpl/pom.xml
@@ -51,10 +51,32 @@
       <artifactId>spring-boot-starter-web</artifactId>
       <exclusions>
         <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-json</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.5</version>
+    <version>2.5.7</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
   <properties>
-    <tomcat.version>9.0.53</tomcat.version>
+    <tomcat.version>9.0.56</tomcat.version>
     <com.fasterxml.jackson.version>2.11.4</com.fasterxml.jackson.version>
     <org.bouncycastle.version>1.68</org.bouncycastle.version>
     <org.jsoup.jsoup.version>1.14.2</org.jsoup.jsoup.version>
@@ -42,6 +42,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <log4j.version>2.16.0</log4j.version>
     <executable-jar-suffix>exe</executable-jar-suffix>
     <project.docker.directory>../../demo</project.docker.directory>
   </properties>

--- a/to0scheduler/to0serviceimpl/pom.xml
+++ b/to0scheduler/to0serviceimpl/pom.xml
@@ -46,11 +46,34 @@
       <artifactId>spring-boot-starter-web</artifactId>
       <exclusions>
         <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-starter-json</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+      <version>${log4j.version}</version>
+      <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+          </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+
 
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
  Upgrading dependencies to the latest version

  org.springframework.boot:spring.* from 2.5.5 ==> 2.5.7
  tomcat => 9.0.56
  log4j => 2.16.0

Signed-off-by: Davis Benny <davis.benny@intel.com>