### PR TITLE
Upgrading log4j version from 2.16.0 to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <tomcat.version>9.0.56</tomcat.version>
     <com.fasterxml.jackson.version>2.11.4</com.fasterxml.jackson.version>
-    <org.bouncycastle.version>1.68</org.bouncycastle.version>
+    <org.bouncycastle.version>1.70</org.bouncycastle.version>
     <org.jsoup.jsoup.version>1.14.2</org.jsoup.jsoup.version>
     <org.apache.httpcomponents.version>4.5.13</org.apache.httpcomponents.version>
     <org.apache.commons.configuration2.version>2.7</org.apache.commons.configuration2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <executable-jar-suffix>exe</executable-jar-suffix>
     <project.docker.directory>../../demo</project.docker.directory>
   </properties>


### PR DESCRIPTION
  Upgrading log4j version from 2.16.0 to 2.17.1.

Signed-off-by: Davis Benny <davis.benny@intel.com>